### PR TITLE
Block mint zero

### DIFF
--- a/contracts/libraries/Positions.sol
+++ b/contracts/libraries/Positions.sol
@@ -42,7 +42,7 @@ library Positions {
         if (params.upper > TickMath.MAX_TICK) revert InvalidUpperTick();
         if (params.lower % int24(state.tickSpread) != 0) revert InvalidLowerTick();
         if (params.upper % int24(state.tickSpread) != 0) revert InvalidUpperTick();
-        // if (params.amount == 0) revert InvalidPositionAmount();
+        if (params.amount == 0) revert InvalidPositionAmount();
         if (params.lower >= params.upper)
             revert InvalidPositionBoundsOrder();
         if (params.zeroForOne) {

--- a/test/contracts/coverpool.ts
+++ b/test/contracts/coverpool.ts
@@ -1504,14 +1504,8 @@ describe('CoverPool Tests', function () {
             balanceOutIncrease: BigNumber.from('116683335274777521987'),
             lowerTickCleared: false,
             upperTickCleared: false,
-            revertMessage: '', // Alice cannot claim at -20 when she should be able to
+            revertMessage: '',
         })
-
-        // Alice cannot claim at this tick since the following tick, -40 is set in the EpochMap when syncing latest
-        // -40 should only be set in the EpochMap if we successfully cross over it.
-        // This can lead to users being able to claim amounts from ticks that have not yet actually
-        // been crossed, potentially perturbing the pool accounting.
-        // In addition to users not being able to claim their filled amounts as shown in this PoC.
     });
 
     it("pool0 - Users cannot claim at the right tick :: GUARDIAN AUDITS", async () => {


### PR DESCRIPTION
This readds the check for `params.amount == 0` in `Positions.validate()` to make sure we don't mint empty ticks.

Users claiming their position can just call `burn()` when they wish to claim.