### PR TITLE
Fix incorrect epoch stamping

### DIFF
--- a/contracts/libraries/Epochs.sol
+++ b/contracts/libraries/Epochs.sol
@@ -153,9 +153,9 @@ library Epochs {
             // rollover deltas pool1
             (cache, pool1) = _rollover(state, cache, pool1, false);
             // accumulate deltas pool1
-            if (cache.nextTickToAccum0 > cache.stopTick0 
-                 && ticks0[cache.nextTickToAccum0].liquidityDeltaMinus > 0) {
-                EpochMap.set(tickMap, cache.nextTickToAccum0, state.accumEpoch);
+            if (cache.nextTickToAccum1 < cache.stopTick1 
+                 && ticks1[cache.nextTickToAccum1].liquidityDeltaMinus > 0) {
+                EpochMap.set(tickMap, cache.nextTickToAccum1, state.accumEpoch);
             }
             {
                 ICoverPoolStructs.AccumulateOutputs memory outputs;


### PR DESCRIPTION
Related to the following:

Invalid Epoch Stamping on Pool 1
Epochs.sol: 156-158
Commit: b19e217d49fefefdbe714b0654011ae1837864d5 - “Merge pull request #45 from poolsharks-protocol/unnecessary-typecast”
 
During syncLatest, Pool1 is utilizing Pool0 ticks when stamping the epoch. This can yield users being locked into their positions & unable to exit due to their end tick being unclaimable at and the previous tick yielding an underflow.
```
if (cache.nextTickToAccum0 > cache.stopTick0 
                 && ticks0[cache.nextTickToAccum0].liquidityDeltaMinus > 0) {
                EpochMap.set(tickMap, cache.nextTickToAccum0, state.accumEpoch);
}
```
