### PR TITLE
V-ALL-PSH-008: Bogus burn event

### DIFF
--- a/contracts/CoverPool.sol
+++ b/contracts/CoverPool.sol
@@ -186,7 +186,8 @@ contract CoverPool is
             );
         }
         // force collection
-        emit Burn(msg.sender, params.lower, params.upper, params.claim, params.zeroForOne, params.amount);
+        if (params.amount > 0)
+            emit Burn(msg.sender, params.lower, params.upper, params.claim, params.zeroForOne, params.amount);
         _collect(
             CollectParams(
                 params.to, //address(0) goes to msg.sender


### PR DESCRIPTION
Skip emitting `Burn()` if `params.amount == 0`.