### PR TITLE
Optional sync on `burn`

### DIFF
--- a/contracts/CoverPool.sol
+++ b/contracts/CoverPool.sol
@@ -143,14 +143,15 @@ contract CoverPool is
     ) external lock {
         if (params.to == address(0)) revert CollectToZeroAddress();
         GlobalState memory state = globalState;
-        (state, pool0, pool1) = Epochs.syncLatest(
-            ticks0,
-            ticks1,
-            tickMap,
-            pool0,
-            pool1,
-            state
-        );
+        if (params.sync)
+            (state, pool0, pool1) = Epochs.syncLatest(
+                ticks0,
+                ticks1,
+                tickMap,
+                pool0,
+                pool1,
+                state
+            );
         Position memory position = params.zeroForOne ? positions0[msg.sender][params.lower][params.upper]
                                                      : positions1[msg.sender][params.lower][params.upper];
         if (position.claimPriceLast > 0

--- a/contracts/interfaces/ICoverPoolStructs.sol
+++ b/contracts/interfaces/ICoverPoolStructs.sol
@@ -82,13 +82,13 @@ interface ICoverPoolStructs {
     }
 
     struct BurnParams {
-        address to; // address(0) should revert
+        address to;
         int24 lower;
         int24 claim;
         int24 upper;
         bool zeroForOne;
         uint128 amount;
-        bool collect;
+        bool sync;
     }
 
     struct CollectParams {

--- a/test/utils/contracts/coverpool.ts
+++ b/test/utils/contracts/coverpool.ts
@@ -471,7 +471,7 @@ export async function validateBurn(params: ValidateBurnParams) {
                 upper: upper,
                 zeroForOne: zeroForOne,
                 amount: liquidityAmount,
-                collect: true
+                sync: true
             })
         await burnTxn.wait()
     } else {
@@ -485,7 +485,7 @@ export async function validateBurn(params: ValidateBurnParams) {
                     upper: upper,
                     zeroForOne: zeroForOne,
                     amount: liquidityAmount,
-                    collect: true
+                    sync: true
                 })
         ).to.be.revertedWith(revertMessage)
         return


### PR DESCRIPTION
This PR makes `Epochs.syncLatest()` optional on `burn()` function calls to avoid Denial of Service attacks.