### PR TITLE
Shift `newLatestTick` by 1/4 of `state.tickSpread` to improve reactiveness

### DIFF
--- a/contracts/libraries/Epochs.sol
+++ b/contracts/libraries/Epochs.sol
@@ -202,6 +202,10 @@ library Epochs {
         }
 
         newLatestTick = TwapOracle.calculateAverageTick(state.inputPool, state.twapLength);
+        /// @dev - shift up/down one quartile to put pool ahead of TWAP
+        if (newLatestTick > state.latestTick)
+             newLatestTick += state.tickSpread / 4;
+        else newLatestTick -= state.tickSpread / 4;
         newLatestTick = newLatestTick / state.tickSpread * state.tickSpread; // even multiple of tickSpread
 
         if (newLatestTick == state.latestTick) {


### PR DESCRIPTION
This PR makes it so we shift the TWAP tick we get back from the `inputPool` by one-fourth of `state.tickSpread`.

In this way a TWAP move from `0` to `30` gets bumped up to `40` if `state.tickSpread` is `40`.

Equally, a TWAP of `40` to `10` gets bumped down to `10` if `state.tickSpread` is `40`.