### PR TITLE
Reentrancy Protection

### DIFF
--- a/contracts/interfaces/ICoverPool.sol
+++ b/contracts/interfaces/ICoverPool.sol
@@ -18,11 +18,17 @@ interface ICoverPool is ICoverPoolStructs {
         bool zeroForOne,
         uint128 amountIn,
         uint160 priceLimit
-    )
-    external
-    returns (
-        // bytes calldata data
+    ) external returns (
         uint256 amountOut
+    );
+
+    function quote(
+        bool zeroForOne,
+        uint128 amountIn,
+        uint160 priceLimit
+    ) external view returns (
+        uint256 inAmount,
+        uint256 outAmount
     );
 
     function collectFees() external returns (


### PR DESCRIPTION
This PR saves `globalState` before any `_transferOut()` calls to avoid potential reentrancy.