### PR TITLE
Simulate sync for `quote()`

### DIFF
--- a/contracts/CoverPool.sol
+++ b/contracts/CoverPool.sol
@@ -294,9 +294,20 @@ contract CoverPool is
         uint256 outAmount
     ) {
         GlobalState memory state = globalState;
+        PoolState memory pool0State;
+        PoolState memory pool1State;
+        (state, pool0State, pool1State) = Epochs.simulateSync(
+            ticks0,
+            ticks1,
+            tickMap,
+            pool0,
+            pool1,
+            state,
+            _immutables()
+        );
         SwapCache memory cache = SwapCache({
-            price: zeroForOne ? pool1.price : pool0.price,
-            liquidity: zeroForOne ? pool1.liquidity : pool0.liquidity,
+            price: zeroForOne ? pool1State.price : pool0State.price,
+            liquidity: zeroForOne ? pool1State.liquidity : pool0State.liquidity,
             amountIn: amountIn,
             auctionDepth: block.timestamp - genesisTime - state.auctionStart,
             auctionBoost: 0,


### PR DESCRIPTION
This PR adds a `simulateSync()` function to the `Epochs` library in order to loop through ticks and unlock liquidity such that the user can see liquidity will be unlocked before calling `swap()`.

The final step of this is to include a syncing fee and show in the `quote()` function how much they will receive in return for syncing up the pool.