### PR TITLE
Check for invalid tick index

### DIFF
--- a/contracts/libraries/EpochMap.sol
+++ b/contracts/libraries/EpochMap.sol
@@ -9,6 +9,7 @@ import '../interfaces/ICoverPoolStructs.sol';
 
 library EpochMap {
 
+    error TickIndexInvalid();
     error TickIndexOverflow();
     error TickIndexUnderflow();
     error BlockIndexOverflow();
@@ -89,6 +90,7 @@ library EpochMap {
         unchecked {
             if (tick > TickMath.MAX_TICK / tickSpread * tickSpread) revert TickIndexOverflow();
             if (tick < TickMath.MIN_TICK / tickSpread * tickSpread) revert TickIndexUnderflow();
+            if (tick % tickSpread != 0) revert TickIndexInvalid();
             tickIndex = uint256(int256((tick - TickMath.MIN_TICK / tickSpread * tickSpread)) / tickSpread);
             wordIndex = tickIndex >> 3;        // 2^3 epochs per word
             blockIndex = tickIndex >> 11;      // 2^8 words per block

--- a/contracts/libraries/TickMap.sol
+++ b/contracts/libraries/TickMap.sol
@@ -6,6 +6,7 @@ import '../interfaces/ICoverPoolStructs.sol';
 
 library TickMap {
 
+    error TickIndexInvalid();
     error TickIndexOverflow();
     error TickIndexUnderflow();
     error BlockIndexOverflow();
@@ -131,6 +132,7 @@ library TickMap {
         unchecked {
             if (tick > TickMath.MAX_TICK / tickSpread * tickSpread) revert TickIndexOverflow();
             if (tick < TickMath.MIN_TICK / tickSpread * tickSpread) revert TickIndexUnderflow();
+            if (tick % tickSpread != 0) revert TickIndexInvalid();
             tickIndex = uint256(int256((tick - TickMath.MIN_TICK / tickSpread * tickSpread)) / tickSpread);
             wordIndex = tickIndex >> 8;   // 2^8 ticks per word
             blockIndex = tickIndex >> 16; // 2^8 words per block


### PR DESCRIPTION
This PR adds a check to `EpochMap` and `TickMap` for ticks passed in that don't respect `tickSpread` (i.e. the mod value is not zero).