### PR TITLE
Check current TWAP array length

### DIFF
--- a/contracts/test/UniswapV3PoolMock.sol
+++ b/contracts/test/UniswapV3PoolMock.sol
@@ -75,7 +75,8 @@ contract UniswapV3PoolMock is IUniswapV3Pool {
         tickCumulative1 = _tickCumulative1;
     }
 
-    function setObservationCardinality(uint16 _observationCardinality) external {
+    function setObservationCardinality(uint16 _observationCardinality, uint16 _observationCardinalityNext) external {
         observationCardinality = _observationCardinality;
+        observationCardinalityNext = _observationCardinalityNext;
     }
 }

--- a/test/contracts/coverpool.ts
+++ b/test/contracts/coverpool.ts
@@ -78,11 +78,11 @@ describe('CoverPool Tests', function () {
 
         await mintSigners20(hre.props.token1, tokenAmount.mul(10), [hre.props.alice, hre.props.bob])
 
-        await hre.props.uniswapV3PoolMock.setObservationCardinality('5')
+        await hre.props.uniswapV3PoolMock.setObservationCardinality('5', '5')
     })
 
     it('pool0 - Should wait until enough observations', async function () {
-        await hre.props.uniswapV3PoolMock.setObservationCardinality('4')
+        await hre.props.uniswapV3PoolMock.setObservationCardinality('4', '5')
         // mint should revert
         await validateMint({
             signer: hre.props.alice,
@@ -130,7 +130,7 @@ describe('CoverPool Tests', function () {
     })
 
     it('pool1 - Should wait until enough observations', async function () {
-        await hre.props.uniswapV3PoolMock.setObservationCardinality('4')
+        await hre.props.uniswapV3PoolMock.setObservationCardinality('4', '5')
         // mint should revert
         await validateMint({
             signer: hre.props.alice,

--- a/test/utils/setup/initialSetup.ts
+++ b/test/utils/setup/initialSetup.ts
@@ -345,7 +345,7 @@ export class InitialSetup {
 
         //TODO: for coverPool2 we need a second mock pool with a different cardinality
 
-        await hre.props.uniswapV3PoolMock.setObservationCardinality('5')
+        await hre.props.uniswapV3PoolMock.setObservationCardinality('5', '5')
 
         return hre.nonce
     }


### PR DESCRIPTION
This PR checks `observationCardinalityNext` (i.e. current max length) as criteria to decide whether the `observations` array needs to be expanded or not.

Previously, it was checking `observationCardinality` (i.e. current length) and then continually trying to increase the length of the `observations` array unnecessarily.

This is a minor improvement as it only saves ~2900 gas units when someone tries to initialize the pool prematurely.