### PR TITLE
Modular Curve Math

### DIFF
--- a/contracts/CoverPool.sol
+++ b/contracts/CoverPool.sol
@@ -23,6 +23,7 @@ contract CoverPool is
     address public immutable token0;
     address public immutable token1;
     address public immutable twapSource;
+    address public immutable curveMath;
     address public immutable inputPool; 
     uint160 public immutable MIN_PRICE;
     uint160 public immutable MAX_PRICE;
@@ -56,6 +57,7 @@ contract CoverPool is
         // set addresses
         owner      = params.owner;
         twapSource = params.twapSource;
+        curveMath  = params.curveMath;
         inputPool  = params.inputPool;
         token0     = params.token0;
         token1     = params.token1;
@@ -148,7 +150,7 @@ contract CoverPool is
                 params.upper,
                 params.zeroForOne
             ),
-            tickSpread
+            _immutables()
         );
         globalState = cache.state;
         _collect(
@@ -443,7 +445,8 @@ contract CoverPool is
         Immutables memory
     ) {
         return Immutables(
-            twapSource,
+            ICurveMath(curveMath),
+            ITwapSource(twapSource),
             inputPool,
             minAmountPerAuction,
             genesisTime,

--- a/contracts/CoverPoolFactory.sol
+++ b/contracts/CoverPoolFactory.sol
@@ -25,6 +25,7 @@ contract CoverPoolFactory is
 
     function createCoverPool(
         bytes32 sourceName,
+        bytes32 curveName,
         address tokenIn,
         address tokenOut,
         uint16 feeTier,
@@ -36,13 +37,15 @@ contract CoverPoolFactory is
         params.token0 = tokenIn < tokenOut ? tokenIn : tokenOut;
         params.token1 = tokenIn < tokenOut ? tokenOut : tokenIn;
         // generate key for pool
-        bytes32 key = keccak256(abi.encodePacked(sourceName, params.token0, params.token1, feeTier, tickSpread, twapLength));
+        bytes32 key = keccak256(abi.encodePacked(sourceName, curveName, params.token0, params.token1, feeTier, tickSpread, twapLength));
         if (coverPools[key] != address(0)) {
             revert PoolAlreadyExists();
         }
         // get twap source
         params.twapSource = ICoverPoolManager(owner).twapSources(sourceName);
         if (params.twapSource == address(0)) revert TwapSourceNotFound();
+        params.curveMath = ICoverPoolManager(owner).curveMaths(curveName);
+        if (params.curveMath == address(0)) revert CurveMathNotFound();
         // get volatility tier config
         params.owner = owner;
         params.config = ICoverPoolManager(owner).volatilityTiers(sourceName, feeTier, tickSpread, twapLength);
@@ -71,6 +74,7 @@ contract CoverPoolFactory is
 
     function getCoverPool(
         bytes32 sourceName,
+        bytes32 curveName,
         address tokenIn,
         address tokenOut,
         uint16 feeTier,
@@ -82,7 +86,7 @@ contract CoverPoolFactory is
         address token1 = tokenIn < tokenOut ? tokenOut : tokenIn;
 
         // get pool address from mapping
-        bytes32 key = keccak256(abi.encodePacked(sourceName, token0, token1, feeTier, tickSpread, twapLength));
+        bytes32 key = keccak256(abi.encodePacked(sourceName, curveName, token0, token1, feeTier, tickSpread, twapLength));
 
         return coverPools[key];
     }

--- a/contracts/base/events/CoverPoolManagerEvents.sol
+++ b/contracts/base/events/CoverPoolManagerEvents.sol
@@ -16,6 +16,10 @@ abstract contract CoverPoolManagerEvents {
         int16   minPositionWidth,
         bool    minLowerPriced
     );
+    event CurveMathEnabled(
+        bytes32 curveName,
+        address curveAddress
+    );
     event TwapSourceEnabled(
         bytes32  sourceName,
         address sourceAddress,

--- a/contracts/base/structs/CoverPoolFactoryStructs.sol
+++ b/contracts/base/structs/CoverPoolFactoryStructs.sol
@@ -7,6 +7,7 @@ abstract contract CoverPoolFactoryStructs is CoverPoolManagerStructs {
     struct CoverPoolParams {
         VolatilityTier config;
         address twapSource;
+        address curveMath;
         address inputPool;
         address owner;
         address token0;

--- a/contracts/base/structs/CoverPoolManagerStructs.sol
+++ b/contracts/base/structs/CoverPoolManagerStructs.sol
@@ -1,7 +1,7 @@
 // SPDX-License-Identifier: BUSL-1.1
 pragma solidity ^0.8.13;
 
-import '../../interfaces/ITwapSource.sol';
+import '../../interfaces/modules/ITwapSource.sol';
 
 interface CoverPoolManagerStructs {
     struct VolatilityTier {

--- a/contracts/interfaces/ICoverPoolFactory.sol
+++ b/contracts/interfaces/ICoverPoolFactory.sol
@@ -3,9 +3,9 @@ pragma solidity ^0.8.13;
 import '../base/storage/CoverPoolFactoryStorage.sol';
 
 abstract contract ICoverPoolFactory is CoverPoolFactoryStorage {
-
     function createCoverPool(
         bytes32 sourceName,
+        bytes32 curveName,
         address tokenIn,
         address tokenOut,
         uint16 fee,
@@ -15,6 +15,7 @@ abstract contract ICoverPoolFactory is CoverPoolFactoryStorage {
 
     function getCoverPool(
         bytes32 sourceName,
+        bytes32 curveName,
         address tokenIn,
         address tokenOut,
         uint16 fee,

--- a/contracts/interfaces/ICoverPoolManager.sol
+++ b/contracts/interfaces/ICoverPoolManager.sol
@@ -13,6 +13,11 @@ interface ICoverPoolManager is CoverPoolManagerStructs {
     ) external view returns (
         address sourceAddress
     );
+    function curveMaths(
+        bytes32 curvename
+    ) external view returns (
+        address curveAddress
+    );
     function volatilityTiers(
         bytes32 sourceName,
         uint16 feeTier,

--- a/contracts/interfaces/ICoverPoolStructs.sol
+++ b/contracts/interfaces/ICoverPoolStructs.sol
@@ -1,6 +1,9 @@
 // SPDX-License-Identifier: BUSL-1.1
 pragma solidity ^0.8.13;
 
+import './modules/ICurveMath.sol';
+import './modules/ITwapSource.sol';
+
 interface ICoverPoolStructs {
     struct GlobalState {
         ProtocolFees protocolFees;
@@ -59,7 +62,8 @@ interface ICoverPoolStructs {
     }
 
     struct Immutables {
-        address twapSource;
+        ICurveMath  curve;
+        ITwapSource source;
         address inputPool;
         uint256 minAmountPerAuction;
         uint32 genesisTime;

--- a/contracts/interfaces/modules/ICurveMath.sol
+++ b/contracts/interfaces/modules/ICurveMath.sol
@@ -1,0 +1,43 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+pragma solidity ^0.8.13;
+
+interface ICurveMath {
+    function getDy(
+        uint256 liquidity,
+        uint256 priceLower,
+        uint256 priceUpper,
+        bool roundUp
+    ) external pure returns (
+        uint256 dy
+    );
+
+    function getDx(
+        uint256 liquidity,
+        uint256 priceLower,
+        uint256 priceUpper,
+        bool roundUp
+    ) external pure returns (
+        uint256 dx
+    );
+
+    function getLiquidityForAmounts(
+        uint256 priceLower,
+        uint256 priceUpper,
+        uint256 currentPrice,
+        uint256 dy,
+        uint256 dx
+    ) external pure returns (
+        uint256 liquidity
+    );
+
+    function getAmountsForLiquidity(
+        uint256 priceLower,
+        uint256 priceUpper,
+        uint256 price,
+        uint256 liquidity,
+        bool roundUp
+    ) external pure returns (
+        uint128 token0amount,
+        uint128 token1amount
+    );
+}

--- a/contracts/interfaces/modules/ITwapSource.sol
+++ b/contracts/interfaces/modules/ITwapSource.sol
@@ -1,9 +1,9 @@
 // SPDX-License-Identifier: GPL-3.0-or-later
 pragma solidity ^0.8.13;
 
-import './ICoverPoolStructs.sol';
+import '../ICoverPoolStructs.sol';
 
-interface ITwapSource is ICoverPoolStructs {
+interface ITwapSource {
     function initialize(
         ICoverPoolStructs.Immutables memory constants
     ) external returns (

--- a/contracts/libraries/Deltas.sol
+++ b/contracts/libraries/Deltas.sol
@@ -1,7 +1,7 @@
 // SPDX-License-Identifier: BUSL-1.1
 pragma solidity ^0.8.13;
 
-import './math/DyDxMath.sol';
+import '../interfaces/modules/ICurveMath.sol';
 import '../interfaces/ICoverPoolStructs.sol';
 
 library Deltas {
@@ -10,20 +10,21 @@ library Deltas {
         uint128 liquidity,
         uint160 priceStart,
         uint160 priceEnd,
-        bool   isPool0
+        bool   isPool0,
+        ICurveMath curve
     ) public pure returns (
         uint128 amountInDeltaMax,
         uint128 amountOutDeltaMax
     ) {
         amountInDeltaMax = uint128(
             isPool0
-                ? DyDxMath.getDy(
+                ? curve.getDy(
                     liquidity,
                     priceEnd,
                     priceStart,
                     false
                 )
-                : DyDxMath.getDx(
+                : curve.getDx(
                     liquidity,
                     priceStart,
                     priceEnd,
@@ -32,13 +33,13 @@ library Deltas {
         );
         amountOutDeltaMax = uint128(
             isPool0
-                ? DyDxMath.getDx(
+                ? curve.getDx(
                     liquidity,
                     priceEnd,
                     priceStart,
                     false
                 )
-                : DyDxMath.getDy(
+                : curve.getDy(
                     liquidity,
                     priceStart,
                     priceEnd,
@@ -51,20 +52,21 @@ library Deltas {
         uint128 liquidity,
         uint160 priceStart,
         uint160 priceEnd,
-        bool   isPool0
+        bool   isPool0,
+        ICurveMath curve
     ) public pure returns (
         uint128 amountInDeltaMax,
         uint128 amountOutDeltaMax
     ) {
         amountInDeltaMax = uint128(
             isPool0
-                ? DyDxMath.getDy(
+                ? curve.getDy(
                     liquidity,
                     priceEnd,
                     priceStart,
                     true
                 )
-                : DyDxMath.getDx(
+                : curve.getDx(
                     liquidity,
                     priceStart,
                     priceEnd,
@@ -73,13 +75,13 @@ library Deltas {
         );
         amountOutDeltaMax = uint128(
             isPool0
-                ? DyDxMath.getDx(
+                ? curve.getDx(
                     liquidity,
                     priceEnd,
                     priceStart,
                     true
                 )
-                : DyDxMath.getDy(
+                : curve.getDy(
                     liquidity,
                     priceStart,
                     priceEnd,
@@ -92,20 +94,21 @@ library Deltas {
         uint128 liquidity,
         uint160 priceStart,
         uint160 priceEnd,
-        bool isPool0
+        bool isPool0,
+        ICurveMath curve
     ) public pure returns (
         uint128 amountInDeltaMax,
         uint128 amountOutDeltaMax
     ) {
         amountInDeltaMax = uint128(
             isPool0
-                ? DyDxMath.getDy(
+                ? curve.getDy(
                     liquidity,
                     priceStart,
                     priceEnd,
                     true
                 )
-                : DyDxMath.getDx(
+                : curve.getDx(
                     liquidity,
                     priceEnd,
                     priceStart,
@@ -114,13 +117,13 @@ library Deltas {
         );
         amountOutDeltaMax = uint128(
             isPool0
-                ? DyDxMath.getDx(
+                ? curve.getDx(
                     liquidity,
                     priceStart,
                     priceEnd,
                     true
                 )
-                : DyDxMath.getDy(
+                : curve.getDy(
                     liquidity,
                     priceEnd,
                     priceStart,
@@ -232,7 +235,8 @@ library Deltas {
     function burnMaxPool(
         ICoverPoolStructs.PoolState memory pool,
         ICoverPoolStructs.UpdatePositionCache memory cache,
-        ICoverPoolStructs.UpdateParams memory params
+        ICoverPoolStructs.UpdateParams memory params,
+        ICurveMath curve
     ) external pure returns (
         ICoverPoolStructs.PoolState memory
     )
@@ -245,7 +249,8 @@ library Deltas {
             params.amount,
             cache.priceSpread,
             cache.position.claimPriceLast,
-            params.zeroForOne
+            params.zeroForOne,
+            curve
         );
         pool.amountInDeltaMaxClaimed  -= pool.amountInDeltaMaxClaimed > amountInMaxClaimedBefore ? amountInMaxClaimedBefore
                                                                                                  : pool.amountInDeltaMaxClaimed;
@@ -351,7 +356,8 @@ library Deltas {
         uint160 priceLower,
         uint160 priceUpper,
         bool   isPool0,
-        bool   isAdded
+        bool   isAdded,
+        ICurveMath curve
     ) external pure returns (
         ICoverPoolStructs.Tick memory,
         ICoverPoolStructs.Deltas memory
@@ -362,12 +368,12 @@ library Deltas {
             (
                 amountInDeltaMax,
                 amountOutDeltaMax
-            ) = max(amount, priceUpper, priceLower, true);
+            ) = max(amount, priceUpper, priceLower, true, curve);
         } else {
             (
                 amountInDeltaMax,
                 amountOutDeltaMax
-            ) = max(amount, priceLower, priceUpper, false);
+            ) = max(amount, priceLower, priceUpper, false, curve);
         }
         if (isAdded) {
             tick.amountInDeltaMaxMinus  += amountInDeltaMax;

--- a/contracts/modules/curves/ConstantProduct.sol
+++ b/contracts/modules/curves/ConstantProduct.sol
@@ -1,10 +1,11 @@
 // SPDX-License-Identifier: GPL-3.0-or-later
 pragma solidity ^0.8.13;
 
-import './FullPrecisionMath.sol';
+import '../../interfaces/modules/ICurveMath.sol';
+import '../../libraries/math/FullPrecisionMath.sol';
 
 /// @notice Math library that facilitates ranged liquidity calculations.
-library DyDxMath {
+contract ConstantProduct is ICurveMath {
     uint256 internal constant Q96 = 0x1000000000000000000000000;
 
     error PriceOutsideBounds();
@@ -77,6 +78,23 @@ library DyDxMath {
                 /// @dev - price should either be priceUpper or priceLower
                 revert PriceOutsideBounds();
             }  
+        }
+    }
+
+    function getAmountsForLiquidity(
+        uint256 priceLower,
+        uint256 priceUpper,
+        uint256 currentPrice,
+        uint256 liquidityAmount,
+        bool roundUp
+    ) external pure returns (uint128 token0amount, uint128 token1amount) {
+        if (priceUpper <= currentPrice) {
+            token1amount = uint128(_getDy(liquidityAmount, priceLower, priceUpper, roundUp));
+        } else if (currentPrice <= priceLower) {
+            token0amount = uint128(_getDx(liquidityAmount, priceLower, priceUpper, roundUp));
+        } else {
+            token0amount = uint128(_getDx(liquidityAmount, currentPrice, priceUpper, roundUp));
+            token1amount = uint128(_getDy(liquidityAmount, priceLower, currentPrice, roundUp));
         }
     }
 }

--- a/contracts/modules/sources/UniswapV3Source.sol
+++ b/contracts/modules/sources/UniswapV3Source.sol
@@ -2,11 +2,11 @@
 pragma solidity ^0.8.13;
 
 import '@openzeppelin/contracts/token/ERC20/IERC20.sol';
-import '../interfaces/external/IUniswapV3Factory.sol';
-import '../interfaces/external/IUniswapV3Pool.sol';
-import '../interfaces/ICoverPoolStructs.sol';
-import '../interfaces/ITwapSource.sol';
-import '../libraries/math/TickMath.sol';
+import '../../interfaces/external/IUniswapV3Factory.sol';
+import '../../interfaces/external/IUniswapV3Pool.sol';
+import '../../interfaces/ICoverPoolStructs.sol';
+import '../../interfaces/modules/ITwapSource.sol';
+import '../../libraries/math/TickMath.sol';
 
 contract UniswapV3Source is ITwapSource {
     error WaitUntilBelowMaxTick();

--- a/contracts/utils/CoverPoolErrors.sol
+++ b/contracts/utils/CoverPoolErrors.sol
@@ -48,6 +48,7 @@ abstract contract CoverPoolFactoryErrors {
     error VolatilityTierNotSupported();
     error InvalidTickSpread();
     error TwapSourceNotFound();
+    error CurveMathNotFound();
     error TickSpreadNotMultipleOfTickSpacing();
     error TickSpreadNotAtLeastDoubleTickSpread();
 }

--- a/test/contracts/coverpool.ts
+++ b/test/contracts/coverpool.ts
@@ -636,7 +636,6 @@ describe('CoverPool Tests', function () {
 
     it('pool0 - Should move TWAP in range, partial fill, sync lower tick, and burn 54', async function () {
         const liquidityAmount4 = BigNumber.from('49902591570441687020675')
-        hre.props.dydxMathLib
 
         await validateSync(0)
 

--- a/test/contracts/coverpoolfactory.ts
+++ b/test/contracts/coverpoolfactory.ts
@@ -21,6 +21,7 @@ describe('CoverPoolFactory Tests', function () {
     const minTickIdx = BigNumber.from('-887272')
     const maxTickIdx = BigNumber.from('887272')
     const uniV3String = ethers.utils.formatBytes32String('UNI-V3')
+    const constantProductString =  ethers.utils.formatBytes32String('CONSTANT-PRODUCT')
 
     before(async function () {
         await gBefore()
@@ -34,6 +35,7 @@ describe('CoverPoolFactory Tests', function () {
                 .connect(hre.props.admin)
                 .createCoverPool(
                     uniV3String,
+                    constantProductString,
                     '0x0000000000000000000000000000000000000000',
                     '0x0000000000000000000000000000000000000000',
                     '500',
@@ -49,6 +51,7 @@ describe('CoverPoolFactory Tests', function () {
                 .connect(hre.props.admin)
                 .createCoverPool(
                     ethers.utils.formatBytes32String('test'),
+                    constantProductString,
                     '0x0000000000000000000000000000000000000000',
                     '0x0000000000000000000000000000000000000000',
                     '500',
@@ -58,12 +61,29 @@ describe('CoverPoolFactory Tests', function () {
         ).to.be.revertedWith('TwapSourceNotFound()')
     })
 
+    it('Should not create pool with invalid curve math', async function () {
+        await expect(
+            hre.props.coverPoolFactory
+                .connect(hre.props.admin)
+                .createCoverPool(
+                    uniV3String,
+                    ethers.utils.formatBytes32String('test'),
+                    '0x0000000000000000000000000000000000000000',
+                    '0x0000000000000000000000000000000000000000',
+                    '500',
+                    '20',
+                    '5'
+                )
+        ).to.be.revertedWith('CurveMathNotFound()')
+    })
+
     it('Should not create pool if the pair already exists', async function () {
         await expect(
             hre.props.coverPoolFactory
                 .connect(hre.props.admin)
                 .createCoverPool(
                     uniV3String,
+                    constantProductString,
                     hre.props.token1.address,
                     hre.props.token0.address,
                     '500',
@@ -79,6 +99,7 @@ describe('CoverPoolFactory Tests', function () {
                 .connect(hre.props.admin)
                 .createCoverPool(
                     uniV3String,
+                    constantProductString,
                     hre.props.token1.address,
                     hre.props.token0.address,
                     '2000',

--- a/test/contracts/curves/constantproduct.ts
+++ b/test/contracts/curves/constantproduct.ts
@@ -24,7 +24,7 @@ describe('DyDxMath Library Tests', function () {
 
     it('Should get accurate dx value when rounding up', async function () {
         expect(
-            await hre.props.dydxMathLib.getDx(
+            await hre.props.constantProduct.getDx(
                 BigNumber.from('49753115595468372952776'),
                 BigNumber.from('79545693927487839655804034730'),
                 BigNumber.from('79625275426524748796330556128'),
@@ -35,7 +35,7 @@ describe('DyDxMath Library Tests', function () {
 
     it('Should get accurate dy value across first tick', async function () {
         expect(
-            await hre.props.dydxMathLib.getDy(
+            await hre.props.constantProduct.getDy(
                 BigNumber.from('49753115595468372952776'),
                 BigNumber.from('79545693927487839655804034730'),
                 BigNumber.from('79625275426524748796330556128'),
@@ -46,7 +46,7 @@ describe('DyDxMath Library Tests', function () {
 
     it('Should get accurate dy value across second tick', async function () {
         expect(
-            await hre.props.dydxMathLib.getDy(
+            await hre.props.constantProduct.getDy(
                 BigNumber.from('49753115595468372952776'),
                 BigNumber.from('79625275426524748796330556128'),
                 BigNumber.from('79704936542881920863903188245'),
@@ -57,7 +57,7 @@ describe('DyDxMath Library Tests', function () {
 
     it('Should get accurate dy value across multiple ticks', async function () {
         expect(
-            await hre.props.dydxMathLib.getDy(
+            await hre.props.constantProduct.getDy(
                 BigNumber.from('49753115595468372952776'),
                 BigNumber.from('79545693927487839655804034730'),
                 BigNumber.from('79704936542881920863903188245'),
@@ -68,14 +68,14 @@ describe('DyDxMath Library Tests', function () {
 
     it('Should revert if getting liquidity value outside price bounds', async function () {
         await expect(
-            hre.props.dydxMathLib.getLiquidityForAmounts(
+            hre.props.constantProduct.getLiquidityForAmounts(
                 BigNumber.from('79386769463160146968577785965'),
                 BigNumber.from('79545693927487839655804034729'),
                 BigNumber.from('99855108194609381495771'),
                 BigNumber.from('20'),
                 BigNumber.from('20')
             )
-        ).to.be.revertedWith('Transaction reverted: library was called directly')
+        ).to.be.revertedWith('PriceOutsideBounds()')
         //TODO: wrong error is reported using hardhat
         // )).to.be.revertedWith("PriceOutsideOfBounds()");
     })

--- a/test/utils/contracts/coverpool.ts
+++ b/test/utils/contracts/coverpool.ts
@@ -337,7 +337,7 @@ export async function validateMint(params: ValidateMintParams) {
                 upper: upper,
                 amount: amountDesired,
                 zeroForOne: zeroForOne
-              })
+            })
         await txn.wait()
     } else {
         await expect(

--- a/test/utils/setup/beforeEachProps.ts
+++ b/test/utils/setup/beforeEachProps.ts
@@ -20,6 +20,7 @@ import {
     EpochMap,
     IUniswapV3Factory,
     IUniswapV3Pool,
+    ConstantProduct,
 } from '../../../typechain'
 import { InitialSetup } from './initialSetup'
 
@@ -32,7 +33,7 @@ export interface BeforeEachProps {
     uniswapV3PoolMock: UniswapV3PoolMock
     tickMapLib: TickMap
     tickMathLib: TickMath
-    dydxMathLib: DyDxMath
+    constantProduct: ConstantProduct
     deltasLib: Deltas
     epochsLib: Epochs
     epochMapLib: EpochMap
@@ -82,7 +83,7 @@ export class GetBeforeEach {
         let uniswapV3PoolMock: UniswapV3PoolMock
         let tickMapLib: TickMap
         let tickMathLib: TickMath
-        let dydxMathLib: DyDxMath
+        let constantProduct: ConstantProduct
         let deltasLib: Deltas
         let epochsLib: Epochs
         let epochMapLib: EpochMap
@@ -110,7 +111,7 @@ export class GetBeforeEach {
             uniswapV3PoolMock,
             tickMapLib,
             tickMathLib,
-            dydxMathLib,
+            constantProduct,
             deltasLib,
             epochsLib,
             epochMapLib,


### PR DESCRIPTION
This PR adds Modular Curve Math for Cover Pools.

Each curve math contract is added by calling `enableCurveMath()` on the `CoverPoolManager` contract.

Each curve math contract must support the interface `ICurveMath`.

In this way each Cover Pool is launched with a specific curve math.

Examples: Constant Product, Constant Sum, Stable Math.