### PR TITLE
Remove unnecessary Q128 constant

### DIFF
--- a/contracts/libraries/Epochs.sol
+++ b/contracts/libraries/Epochs.sol
@@ -9,8 +9,6 @@ import './TickMap.sol';
 import './EpochMap.sol';
 
 library Epochs {
-    uint256 internal constant Q128 = 0x100000000000000000000000000000000;
-
     event Sync(
         uint160 pool0Price,
         uint160 pool1Price,


### PR DESCRIPTION
This addresses the audit issue GLOBAL-2 from the Guardian Audits report.
![image](https://github.com/poolsharks-protocol/cover/assets/84204260/1d6989af-e74b-4b16-b5f2-03658a6ee18b)

