### PR TITLE
Errantly unsetting ticks

### DIFF
--- a/contracts/CoverPool.sol
+++ b/contracts/CoverPool.sol
@@ -60,8 +60,7 @@ contract CoverPool is
             cache.pool0, 
             cache.pool1
         ) = Epochs.syncLatest(
-            ticks0,
-            ticks1,
+            ticks,
             tickMap,
             cache.pool0,
             cache.pool1,
@@ -72,7 +71,7 @@ contract CoverPool is
             params,
             cache,
             tickMap,
-            params.zeroForOne ? ticks0 : ticks1,
+            ticks,
             params.zeroForOne ? positions0 : positions1
         );
         pool0 = cache.pool0;
@@ -99,8 +98,7 @@ contract CoverPool is
                 cache.pool0,
                 cache.pool1
             ) = Epochs.syncLatest(
-                ticks0,
-                ticks1,
+                ticks,
                 tickMap,
                 cache.pool0,
                 cache.pool1,
@@ -111,7 +109,7 @@ contract CoverPool is
             params, 
             cache, 
             tickMap,
-            params.zeroForOne ? ticks0 : ticks1,
+            ticks,
             params.zeroForOne ? positions0 : positions1
         );
         pool0 = cache.pool0;
@@ -137,8 +135,7 @@ contract CoverPool is
             cache.pool0,
             cache.pool1
         ) = Epochs.syncLatest(
-            ticks0,
-            ticks1,
+            ticks,
             tickMap,
             cache.pool0,
             cache.pool1,
@@ -185,8 +182,7 @@ contract CoverPool is
             cache.pool0,
             cache.pool1
         ) = Epochs.simulateSync(
-            ticks0,
-            ticks1,
+            ticks,
             tickMap,
             cache.pool0,
             cache.pool1,
@@ -216,7 +212,7 @@ contract CoverPool is
     ) {
         return Positions.snapshot(
             params.zeroForOne ? positions0 : positions1,
-            params.zeroForOne ? ticks0 : ticks1,
+            ticks,
             tickMap,
             globalState,
             params.zeroForOne ? pool0 : pool1,

--- a/contracts/CoverPoolFactory.sol
+++ b/contracts/CoverPoolFactory.sol
@@ -3,17 +3,16 @@ pragma solidity ^0.8.13;
 
 import './CoverPool.sol';
 import './external/solady/LibClone.sol';
-import './interfaces/ICoverPoolStructs.sol';
+import './interfaces/structs/CoverPoolStructs.sol';
 import './interfaces/ICoverPoolFactory.sol';
 import './base/events/CoverPoolFactoryEvents.sol';
-import './base/structs/CoverPoolManagerStructs.sol';
 import './utils/CoverPoolErrors.sol';
 
 contract CoverPoolFactory is 
     ICoverPoolFactory,
     CoverPoolFactoryEvents,
     CoverPoolFactoryErrors,
-    ICoverPoolStructs
+    CoverPoolStructs
 {
     using LibClone for address;
 

--- a/contracts/base/storage/CoverPoolStorage.sol
+++ b/contracts/base/storage/CoverPoolStorage.sol
@@ -1,18 +1,16 @@
 // SPDX-License-Identifier: BUSL-1.1
 pragma solidity ^0.8.13;
 
-import '../../interfaces/ICoverPoolStructs.sol';
+import '../../interfaces/structs/CoverPoolStructs.sol';
 import '../../interfaces/ICoverPoolFactory.sol';
 import '../../utils/CoverPoolErrors.sol';
 
-abstract contract CoverPoolStorage is ICoverPoolStructs, CoverPoolErrors {
+abstract contract CoverPoolStorage is CoverPoolStructs, CoverPoolErrors {
     GlobalState public globalState;
-    PoolState public pool0; /// @dev State for token0 as output
-    PoolState public pool1; /// @dev State for token1 as output
+    PoolState public pool0; /// @dev pool with token0 liquidity
+    PoolState public pool1; /// @dev pool with token1 liquidity
     TickMap public tickMap;
-    address public feeTo;
-    mapping(int24 => Tick) public ticks0; /// @dev Ticks containing token0 as output
-    mapping(int24 => Tick) public ticks1; /// @dev Ticks containing token1 as output
+    mapping(int24 => Tick) public ticks; /// @dev price ticks with delta values
     mapping(uint256 => CoverPosition) public positions0; //positions with token0 deposited
     mapping(uint256 => CoverPosition) public positions1; //positions with token1 deposited
 }

--- a/contracts/base/structs/CoverPoolFactoryStructs.sol
+++ b/contracts/base/structs/CoverPoolFactoryStructs.sol
@@ -1,8 +1,0 @@
-// SPDX-License-Identifier: BUSL-1.1
-pragma solidity ^0.8.13;
-
-import '../../interfaces/modules/sources/ITwapSource.sol';
-
-interface CoverPoolManagerStructs {
-    
-}

--- a/contracts/base/structs/CoverPoolManagerStructs.sol
+++ b/contracts/base/structs/CoverPoolManagerStructs.sol
@@ -1,8 +1,0 @@
-// SPDX-License-Identifier: BUSL-1.1
-pragma solidity ^0.8.13;
-
-import '../../interfaces/modules/sources/ITwapSource.sol';
-
-interface CoverPoolManagerStructs {
-    
-}

--- a/contracts/interfaces/ICoverPool.sol
+++ b/contracts/interfaces/ICoverPool.sol
@@ -1,7 +1,7 @@
 // SPDX-License-Identifier: GPL-3.0-or-later
 pragma solidity ^0.8.13;
 
-import './ICoverPoolStructs.sol';
+import './structs/CoverPoolStructs.sol';
 import './structs/PoolsharkStructs.sol';
 
 /**
@@ -9,7 +9,7 @@ import './structs/PoolsharkStructs.sol';
  * @author Poolshark
  * @notice Defines the basic interface for a Cover Pool.
  */
-interface ICoverPool is ICoverPoolStructs, PoolsharkStructs {
+interface ICoverPool is CoverPoolStructs, PoolsharkStructs {
     /**
      * @custom:struct MintParams
      */

--- a/contracts/interfaces/ICoverPoolManager.sol
+++ b/contracts/interfaces/ICoverPoolManager.sol
@@ -1,10 +1,10 @@
 // SPDX-License-Identifier: GPL-3.0-or-later
 pragma solidity 0.8.13;
 
-import '../interfaces/ICoverPoolStructs.sol';
+import '../interfaces/structs/CoverPoolStructs.sol';
 
 /// @notice CoverPoolManager interface
-interface ICoverPoolManager is ICoverPoolStructs {
+interface ICoverPoolManager is CoverPoolStructs {
     function owner() external view returns (address);
     function feeTo() external view returns (address);
     function poolTypes(

--- a/contracts/interfaces/modules/sources/ITwapSource.sol
+++ b/contracts/interfaces/modules/sources/ITwapSource.sol
@@ -1,18 +1,18 @@
 // SPDX-License-Identifier: GPL-3.0-or-later
 pragma solidity ^0.8.13;
 
-import '../../ICoverPoolStructs.sol';
+import '../../structs/CoverPoolStructs.sol';
 
 interface ITwapSource {
     function initialize(
-        ICoverPoolStructs.Immutables memory constants
+        CoverPoolStructs.Immutables memory constants
     ) external returns (
         uint8 initializable,
         int24 startingTick
     );
 
     function calculateAverageTick(
-        ICoverPoolStructs.Immutables memory constants,
+        CoverPoolStructs.Immutables memory constants,
         int24 latestTick
     ) external view returns (
         int24 averageTick

--- a/contracts/interfaces/structs/CoverPoolStructs.sol
+++ b/contracts/interfaces/structs/CoverPoolStructs.sol
@@ -1,9 +1,9 @@
 // SPDX-License-Identifier: BUSL-1.1
 pragma solidity ^0.8.13;
 
-import './modules/sources/ITwapSource.sol';
+import '../modules/sources/ITwapSource.sol';
 
-interface ICoverPoolStructs {
+interface CoverPoolStructs {
     struct GlobalState {
         ProtocolFees protocolFees;
         uint160  latestPrice;      /// @dev price of latestTick
@@ -34,8 +34,9 @@ interface ICoverPoolStructs {
     }
 
     struct Tick {
-        Deltas deltas;                    
-        int128  liquidityDelta;
+        Deltas deltas0;
+        Deltas deltas1;                    
+        int128 liquidityDelta;
         uint128 amountInDeltaMaxMinus;
         uint128 amountOutDeltaMaxMinus;
         uint128 amountInDeltaMaxStashed;

--- a/contracts/interfaces/structs/CoverPoolStructs.sol
+++ b/contracts/interfaces/structs/CoverPoolStructs.sol
@@ -41,6 +41,7 @@ interface CoverPoolStructs {
         uint128 amountOutDeltaMaxMinus;
         uint128 amountInDeltaMaxStashed;
         uint128 amountOutDeltaMaxStashed;
+        bool pool0Stash;
     }
 
     struct Deltas {

--- a/contracts/libraries/Claims.sol
+++ b/contracts/libraries/Claims.sol
@@ -86,7 +86,7 @@ library Claims {
     function getDeltas(
         CoverPoolStructs.UpdatePositionCache memory cache,
         CoverPoolStructs.UpdateParams memory params
-    ) external view returns (
+    ) external pure returns (
         CoverPoolStructs.UpdatePositionCache memory
     ) {
         // transfer deltas into cache

--- a/contracts/libraries/Claims.sol
+++ b/contracts/libraries/Claims.sol
@@ -86,7 +86,7 @@ library Claims {
     function getDeltas(
         CoverPoolStructs.UpdatePositionCache memory cache,
         CoverPoolStructs.UpdateParams memory params
-    ) external pure returns (
+    ) external view returns (
         CoverPoolStructs.UpdatePositionCache memory
     ) {
         // transfer deltas into cache

--- a/contracts/libraries/Deltas.sol
+++ b/contracts/libraries/Deltas.sol
@@ -3,7 +3,6 @@ pragma solidity ^0.8.13;
 
 import '../interfaces/structs/CoverPoolStructs.sol';
 import './math/ConstantProduct.sol';
-
 library Deltas {
 
     function max(
@@ -337,8 +336,10 @@ library Deltas {
         toTick.amountOutDeltaMaxStashed += fromDeltas.amountOutDeltaMax;
         if (isPool0) {
             toTick.deltas0 = toDeltas;
+            toTick.pool0Stash = true;
         } else {
             toTick.deltas1 = toDeltas;
+            toTick.pool0Stash = false;
         }
         fromDeltas = CoverPoolStructs.Deltas(0,0,0,0);
         return (fromDeltas, toTick);
@@ -368,19 +369,19 @@ library Deltas {
         locals.totalDeltaMax = uint256(fromTick.amountInDeltaMaxStashed) + uint256(locals.fromDeltas.amountInDeltaMax);
         
         if (locals.totalDeltaMax > 0) {
-            uint256 percentStashed = uint256(fromTick.amountInDeltaMaxStashed) * 1e38 / locals.totalDeltaMax;
-            uint128 amountInDeltaChange = uint128(uint256(locals.fromDeltas.amountInDelta) * percentStashed / 1e38);
-            locals.fromDeltas.amountInDelta -= amountInDeltaChange;
-            toDeltas.amountInDelta += amountInDeltaChange;
+            locals.percentStashed = uint256(fromTick.amountInDeltaMaxStashed) * 1e38 / locals.totalDeltaMax;
+            locals.amountInDeltaChange = uint128(uint256(locals.fromDeltas.amountInDelta) * locals.percentStashed / 1e38);
+            locals.fromDeltas.amountInDelta -= locals.amountInDeltaChange;
+            toDeltas.amountInDelta += locals.amountInDeltaChange;
         }
         
         locals.totalDeltaMax = uint256(fromTick.amountOutDeltaMaxStashed) + uint256(locals.fromDeltas.amountOutDeltaMax);
         
         if (locals.totalDeltaMax > 0) {
-            uint256 percentStashed = uint256(fromTick.amountOutDeltaMaxStashed) * 1e38 / locals.totalDeltaMax;
-            uint128 amountOutDeltaChange = uint128(uint256(locals.fromDeltas.amountOutDelta) * percentStashed / 1e38);
-            locals.fromDeltas.amountOutDelta -= amountOutDeltaChange;
-            toDeltas.amountOutDelta += amountOutDeltaChange;
+            locals.percentStashed = uint256(fromTick.amountOutDeltaMaxStashed) * 1e38 / locals.totalDeltaMax;
+            locals.amountOutDeltaChange = uint128(uint256(locals.fromDeltas.amountOutDelta) * locals.percentStashed / 1e38);
+            locals.fromDeltas.amountOutDelta -= locals.amountOutDeltaChange;
+            toDeltas.amountOutDelta += locals.amountOutDeltaChange;
         }
         if (isPool0) {
             fromTick.deltas0 = locals.fromDeltas;
@@ -389,6 +390,7 @@ library Deltas {
         }
         fromTick.amountInDeltaMaxStashed = 0;
         fromTick.amountOutDeltaMaxStashed = 0;
+
         return (fromTick, toDeltas);
     }
 

--- a/contracts/libraries/EpochMap.sol
+++ b/contracts/libraries/EpochMap.sol
@@ -2,14 +2,14 @@
 pragma solidity ^0.8.13;
 
 import './math/ConstantProduct.sol';
-import '../interfaces/ICoverPoolStructs.sol';
+import '../interfaces/structs/CoverPoolStructs.sol';
 
 library EpochMap {
     function set(
         int24  tick,
         uint256 epoch,
-        ICoverPoolStructs.TickMap storage tickMap,
-        ICoverPoolStructs.Immutables memory constants
+        CoverPoolStructs.TickMap storage tickMap,
+        CoverPoolStructs.Immutables memory constants
     ) external {
         (
             uint256 tickIndex,
@@ -29,8 +29,8 @@ library EpochMap {
 
     function unset(
         int24 tick,
-        ICoverPoolStructs.TickMap storage tickMap,
-        ICoverPoolStructs.Immutables memory constants
+        CoverPoolStructs.TickMap storage tickMap,
+        CoverPoolStructs.Immutables memory constants
     ) external {
         (
             uint256 tickIndex,
@@ -48,8 +48,8 @@ library EpochMap {
 
     function get(
         int24 tick,
-        ICoverPoolStructs.TickMap storage tickMap,
-        ICoverPoolStructs.Immutables memory constants
+        CoverPoolStructs.TickMap storage tickMap,
+        CoverPoolStructs.Immutables memory constants
     ) external view returns (
         uint32 epoch
     ) {
@@ -70,7 +70,7 @@ library EpochMap {
 
     function getIndices(
         int24 tick,
-        ICoverPoolStructs.Immutables memory constants
+        CoverPoolStructs.Immutables memory constants
     ) public pure returns (
             uint256 tickIndex,
             uint256 wordIndex,
@@ -92,7 +92,7 @@ library EpochMap {
 
     function _tick (
         uint256 tickIndex,
-        ICoverPoolStructs.Immutables memory constants
+        CoverPoolStructs.Immutables memory constants
     ) internal pure returns (
         int24 tick
     ) {

--- a/contracts/libraries/Epochs.sol
+++ b/contracts/libraries/Epochs.sol
@@ -2,7 +2,7 @@
 pragma solidity ^0.8.13;
 
 import '../interfaces/modules/sources/ITwapSource.sol';
-import '../interfaces/ICoverPoolStructs.sol';
+import '../interfaces/structs/CoverPoolStructs.sol';
 import './Deltas.sol';
 import './Ticks.sol';
 import './TickMap.sol';
@@ -50,34 +50,33 @@ library Epochs {
     );
 
     function simulateSync(
-        mapping(int24 => ICoverPoolStructs.Tick) storage ticks0,
-        mapping(int24 => ICoverPoolStructs.Tick) storage ticks1,
-        ICoverPoolStructs.TickMap storage tickMap,
-        ICoverPoolStructs.PoolState memory pool0,
-        ICoverPoolStructs.PoolState memory pool1,
-        ICoverPoolStructs.GlobalState memory state,
-        ICoverPoolStructs.Immutables memory constants
+        mapping(int24 => CoverPoolStructs.Tick) storage ticks,
+        CoverPoolStructs.TickMap storage tickMap,
+        CoverPoolStructs.PoolState memory pool0,
+        CoverPoolStructs.PoolState memory pool1,
+        CoverPoolStructs.GlobalState memory state,
+        CoverPoolStructs.Immutables memory constants
     ) external view returns (
-        ICoverPoolStructs.GlobalState memory,
-        ICoverPoolStructs.SyncFees memory,
-        ICoverPoolStructs.PoolState memory,
-        ICoverPoolStructs.PoolState memory
+        CoverPoolStructs.GlobalState memory,
+        CoverPoolStructs.SyncFees memory,
+        CoverPoolStructs.PoolState memory,
+        CoverPoolStructs.PoolState memory
     ) {
-        ICoverPoolStructs.AccumulateCache memory cache;
+        CoverPoolStructs.AccumulateCache memory cache;
         {
             bool earlyReturn;
             (cache.newLatestTick, earlyReturn) = _syncTick(state, constants);
             if (earlyReturn) {
-                return (state, ICoverPoolStructs.SyncFees(0, 0), pool0, pool1);
+                return (state, CoverPoolStructs.SyncFees(0, 0), pool0, pool1);
             }
             // else we have a TWAP update
         }
 
         // setup cache
-        cache = ICoverPoolStructs.AccumulateCache({
-            deltas0: ICoverPoolStructs.Deltas(0, 0, 0, 0), // deltas for pool0
-            deltas1: ICoverPoolStructs.Deltas(0, 0, 0, 0),  // deltas for pool1
-            syncFees: ICoverPoolStructs.SyncFees(0, 0),
+        cache = CoverPoolStructs.AccumulateCache({
+            deltas0: CoverPoolStructs.Deltas(0, 0, 0, 0), // deltas for pool0
+            deltas1: CoverPoolStructs.Deltas(0, 0, 0, 0),  // deltas for pool1
+            syncFees: CoverPoolStructs.SyncFees(0, 0),
             newLatestTick: cache.newLatestTick,
             nextTickToCross0: state.latestTick, // above
             nextTickToCross1: state.latestTick, // below
@@ -97,7 +96,7 @@ library Epochs {
             // keep looping until accumulation reaches stopTick0 
             if (cache.nextTickToAccum0 >= cache.stopTick0) {
                 (pool0.liquidity, cache.nextTickToCross0, cache.nextTickToAccum0) = _cross(
-                    ticks0[cache.nextTickToAccum0].liquidityDelta,
+                    ticks[cache.nextTickToAccum0].liquidityDelta,
                     tickMap,
                     constants,
                     cache.nextTickToCross0,
@@ -113,7 +112,7 @@ library Epochs {
             // keep looping until accumulation reaches stopTick1 
             if (cache.nextTickToAccum1 <= cache.stopTick1) {
                 (pool1.liquidity, cache.nextTickToCross1, cache.nextTickToAccum1) = _cross(
-                    ticks1[cache.nextTickToAccum1].liquidityDelta,
+                    ticks[cache.nextTickToAccum1].liquidityDelta,
                     tickMap,
                     constants,
                     cache.nextTickToCross1,
@@ -146,26 +145,25 @@ library Epochs {
     }
 
     function syncLatest(
-        mapping(int24 => ICoverPoolStructs.Tick) storage ticks0,
-        mapping(int24 => ICoverPoolStructs.Tick) storage ticks1,
-        ICoverPoolStructs.TickMap storage tickMap,
-        ICoverPoolStructs.PoolState memory pool0,
-        ICoverPoolStructs.PoolState memory pool1,
-        ICoverPoolStructs.GlobalState memory state,
-        ICoverPoolStructs.Immutables memory constants
+        mapping(int24 => CoverPoolStructs.Tick) storage ticks,
+        CoverPoolStructs.TickMap storage tickMap,
+        CoverPoolStructs.PoolState memory pool0,
+        CoverPoolStructs.PoolState memory pool1,
+        CoverPoolStructs.GlobalState memory state,
+        CoverPoolStructs.Immutables memory constants
     ) external returns (
-        ICoverPoolStructs.GlobalState memory,
-        ICoverPoolStructs.SyncFees memory,
-        ICoverPoolStructs.PoolState memory,
-        ICoverPoolStructs.PoolState memory
+        CoverPoolStructs.GlobalState memory,
+        CoverPoolStructs.SyncFees memory,
+        CoverPoolStructs.PoolState memory,
+        CoverPoolStructs.PoolState memory
     )
     {
-        ICoverPoolStructs.AccumulateCache memory cache;
+        CoverPoolStructs.AccumulateCache memory cache;
         {
             bool earlyReturn;
             (cache.newLatestTick, earlyReturn) = _syncTick(state, constants);
             if (earlyReturn) {
-                return (state, ICoverPoolStructs.SyncFees(0,0), pool0, pool1);
+                return (state, CoverPoolStructs.SyncFees(0,0), pool0, pool1);
             }
             // else we have a TWAP update
         }
@@ -174,10 +172,10 @@ library Epochs {
         state.accumEpoch += 1;
 
         // setup cache
-        cache = ICoverPoolStructs.AccumulateCache({
-            deltas0: ICoverPoolStructs.Deltas(0, 0, 0, 0), // deltas for pool0
-            deltas1: ICoverPoolStructs.Deltas(0, 0, 0, 0),  // deltas for pool1
-            syncFees: ICoverPoolStructs.SyncFees(0,0),
+        cache = CoverPoolStructs.AccumulateCache({
+            deltas0: CoverPoolStructs.Deltas(0, 0, 0, 0), // deltas for pool0
+            deltas1: CoverPoolStructs.Deltas(0, 0, 0, 0),  // deltas for pool1
+            syncFees: CoverPoolStructs.SyncFees(0,0),
             newLatestTick: cache.newLatestTick,
             nextTickToCross0: state.latestTick, // above
             nextTickToCross1: state.latestTick, // below
@@ -195,14 +193,14 @@ library Epochs {
             // get values from current auction
             (cache, pool0) = _rollover(state, cache, pool0, constants, true);
             if (cache.nextTickToAccum0 > cache.stopTick0 
-                 && ticks0[cache.nextTickToAccum0].amountInDeltaMaxMinus > 0) {
+                 && ticks[cache.nextTickToAccum0].amountInDeltaMaxMinus > 0) {
                 EpochMap.set(cache.nextTickToAccum0, state.accumEpoch, tickMap, constants);
             }
             // accumulate to next tick
-            ICoverPoolStructs.AccumulateParams memory params = ICoverPoolStructs.AccumulateParams({
+            CoverPoolStructs.AccumulateParams memory params = CoverPoolStructs.AccumulateParams({
                 deltas: cache.deltas0,
-                crossTick: ticks0[cache.nextTickToCross0],
-                accumTick: ticks0[cache.nextTickToAccum0],
+                crossTick: ticks[cache.nextTickToCross0],
+                accumTick: ticks[cache.nextTickToAccum0],
                 updateAccumDeltas: cache.newLatestTick > state.latestTick
                                             ? cache.nextTickToAccum0 == cache.stopTick0
                                             : cache.nextTickToAccum0 >= cache.stopTick0,
@@ -215,9 +213,9 @@ library Epochs {
             );
             /// @dev - deltas in cache updated after _accumulate
             cache.deltas0 = params.deltas;
-            ticks0[cache.nextTickToAccum0] = params.accumTick;
+            ticks[cache.nextTickToAccum0] = params.accumTick;
             Ticks.cleanup(
-               ticks0,
+               ticks,
                tickMap,
                constants,
                params.crossTick,
@@ -227,7 +225,7 @@ library Epochs {
             // keep looping until accumulation reaches stopTick0 
             if (cache.nextTickToAccum0 >= cache.stopTick0) {
                 (pool0.liquidity, cache.nextTickToCross0, cache.nextTickToAccum0) = _cross(
-                    ticks0[cache.nextTickToAccum0].liquidityDelta,
+                    ticks[cache.nextTickToAccum0].liquidityDelta,
                     tickMap,
                     constants,
                     cache.nextTickToCross0,
@@ -243,7 +241,7 @@ library Epochs {
             if (cache.nextTickToAccum0 != cache.stopTick0) {
                 TickMap.set(cache.stopTick0, tickMap, constants);
             }
-            ICoverPoolStructs.Tick memory stopTick0 = ticks0[cache.stopTick0];
+            CoverPoolStructs.Tick memory stopTick0 = ticks[cache.stopTick0];
             // checkpoint at stopTick0
             (stopTick0) = _stash(
                 stopTick0,
@@ -253,7 +251,7 @@ library Epochs {
                 true
             );
             EpochMap.set(cache.stopTick0, state.accumEpoch, tickMap, constants);
-            ticks0[cache.stopTick0] = stopTick0;
+            ticks[cache.stopTick0] = stopTick0;
         }
 
         while (true) {
@@ -261,14 +259,14 @@ library Epochs {
             (cache, pool1) = _rollover(state, cache, pool1, constants, false);
             // accumulate deltas pool1
             if (cache.nextTickToAccum1 < cache.stopTick1 
-                 && ticks1[cache.nextTickToAccum1].amountInDeltaMaxMinus > 0) {
+                 && ticks[cache.nextTickToAccum1].amountInDeltaMaxMinus > 0) {
                 EpochMap.set(cache.nextTickToAccum1, state.accumEpoch, tickMap, constants);
             }
             {
-                ICoverPoolStructs.AccumulateParams memory params = ICoverPoolStructs.AccumulateParams({
+                CoverPoolStructs.AccumulateParams memory params = CoverPoolStructs.AccumulateParams({
                     deltas: cache.deltas1,
-                    crossTick: ticks1[cache.nextTickToCross1],
-                    accumTick: ticks1[cache.nextTickToAccum1],
+                    crossTick: ticks[cache.nextTickToCross1],
+                    accumTick: ticks[cache.nextTickToAccum1],
                     updateAccumDeltas: cache.newLatestTick > state.latestTick
                                                 ? cache.nextTickToAccum1 <= cache.stopTick1
                                                 : cache.nextTickToAccum1 == cache.stopTick1,
@@ -281,9 +279,9 @@ library Epochs {
                 );
                 /// @dev - deltas in cache updated after _accumulate
                 cache.deltas1 = params.deltas;
-                ticks1[cache.nextTickToAccum1] = params.accumTick;
+                ticks[cache.nextTickToAccum1] = params.accumTick;
                 Ticks.cleanup(
-                    ticks1,
+                    ticks,
                     tickMap,
                     constants,
                     params.crossTick,
@@ -293,7 +291,7 @@ library Epochs {
             // keep looping until accumulation reaches stopTick1 
             if (cache.nextTickToAccum1 <= cache.stopTick1) {
                 (pool1.liquidity, cache.nextTickToCross1, cache.nextTickToAccum1) = _cross(
-                    ticks1[cache.nextTickToAccum1].liquidityDelta,
+                    ticks[cache.nextTickToAccum1].liquidityDelta,
                     tickMap,
                     constants,
                     cache.nextTickToCross1,
@@ -309,7 +307,7 @@ library Epochs {
             if (cache.nextTickToAccum1 != cache.stopTick1) {
                 TickMap.set(cache.stopTick1, tickMap, constants);
             }
-            ICoverPoolStructs.Tick memory stopTick1 = ticks1[cache.stopTick1];
+            CoverPoolStructs.Tick memory stopTick1 = ticks[cache.stopTick1];
             // update deltas on stopTick
             (stopTick1) = _stash(
                 stopTick1,
@@ -318,7 +316,7 @@ library Epochs {
                 pool1.liquidity,
                 false
             );
-            ticks1[cache.stopTick1] = stopTick1;
+            ticks[cache.stopTick1] = stopTick1;
             EpochMap.set(cache.stopTick1, state.accumEpoch, tickMap, constants);
         }
         // update ending pool price for fully filled auction
@@ -352,8 +350,8 @@ library Epochs {
     }
 
     function _syncTick(
-        ICoverPoolStructs.GlobalState memory state,
-        ICoverPoolStructs.Immutables memory constants
+        CoverPoolStructs.GlobalState memory state,
+        CoverPoolStructs.Immutables memory constants
     ) internal view returns(
         int24 newLatestTick,
         bool
@@ -400,14 +398,14 @@ library Epochs {
     }
 
     function _rollover(
-        ICoverPoolStructs.GlobalState memory state,
-        ICoverPoolStructs.AccumulateCache memory cache,
-        ICoverPoolStructs.PoolState memory pool,
-        ICoverPoolStructs.Immutables memory constants,
+        CoverPoolStructs.GlobalState memory state,
+        CoverPoolStructs.AccumulateCache memory cache,
+        CoverPoolStructs.PoolState memory pool,
+        CoverPoolStructs.Immutables memory constants,
         bool isPool0
     ) internal pure returns (
-        ICoverPoolStructs.AccumulateCache memory,
-        ICoverPoolStructs.PoolState memory
+        CoverPoolStructs.AccumulateCache memory,
+        CoverPoolStructs.PoolState memory
     ) {
         //TODO: add syncing fee
         if (pool.liquidity == 0) {
@@ -518,16 +516,16 @@ library Epochs {
     }
 
     function _accumulate(
-        ICoverPoolStructs.AccumulateCache memory cache,
-        ICoverPoolStructs.AccumulateParams memory params,
-        ICoverPoolStructs.GlobalState memory state
+        CoverPoolStructs.AccumulateCache memory cache,
+        CoverPoolStructs.AccumulateParams memory params,
+        CoverPoolStructs.GlobalState memory state
     ) internal returns (
-        ICoverPoolStructs.AccumulateParams memory
+        CoverPoolStructs.AccumulateParams memory
     ) {
         if (params.crossTick.amountInDeltaMaxStashed > 0) {
             /// @dev - else we migrate carry deltas onto cache
             // add carry amounts to cache
-            (params.crossTick, params.deltas) = Deltas.unstash(params.crossTick, params.deltas);
+            (params.crossTick, params.deltas) = Deltas.unstash(params.crossTick, params.deltas, params.isPool0);
             // clear out stash
             params.crossTick.amountInDeltaMaxStashed  = 0;
             params.crossTick.amountOutDeltaMaxStashed = 0;
@@ -538,7 +536,8 @@ library Epochs {
         }
         if (params.updateAccumDeltas) {
             // migrate carry deltas from cache to accum tick
-            ICoverPoolStructs.Deltas memory accumDeltas = params.accumTick.deltas;
+            CoverPoolStructs.Deltas memory accumDeltas = params.isPool0 ? params.accumTick.deltas0
+                                                                        : params.accumTick.deltas1;
             if (params.accumTick.amountInDeltaMaxMinus > 0) {
                 // calculate percent of deltas left on tick
                 if (params.deltas.amountInDeltaMax > 0 && params.deltas.amountOutDeltaMax > 0) {
@@ -571,7 +570,11 @@ library Epochs {
 
                 // clear out delta max minus and save on tick
                 params.accumTick.amountInDeltaMaxMinus  = 0;
-                params.accumTick.deltas = accumDeltas;
+                if (params.isPool0) {
+                    params.accumTick.deltas0 = accumDeltas;
+                } else {
+                    params.accumTick.deltas1 = accumDeltas;
+                }
 
                 emit FinalDeltasAccumulated(
                     accumDeltas.amountInDelta,
@@ -593,8 +596,8 @@ library Epochs {
     //maybe call ticks on msg.sender to get tick
     function _cross(
         int128 liquidityDelta,
-        ICoverPoolStructs.TickMap storage tickMap,
-        ICoverPoolStructs.Immutables memory constants,
+        CoverPoolStructs.TickMap storage tickMap,
+        CoverPoolStructs.Immutables memory constants,
         int24 nextTickToCross,
         int24 nextTickToAccum,
         uint128 currentLiquidity,
@@ -621,16 +624,16 @@ library Epochs {
     }
 
     function _stash(
-        ICoverPoolStructs.Tick memory stashTick,
-        ICoverPoolStructs.AccumulateCache memory cache,
-        ICoverPoolStructs.GlobalState memory state,
+        CoverPoolStructs.Tick memory stashTick,
+        CoverPoolStructs.AccumulateCache memory cache,
+        CoverPoolStructs.GlobalState memory state,
         uint128 currentLiquidity,
         bool isPool0
-    ) internal returns (ICoverPoolStructs.Tick memory) {
+    ) internal returns (CoverPoolStructs.Tick memory) {
         // return since there is nothing to update
         if (currentLiquidity == 0) return (stashTick);
         // handle deltas
-        ICoverPoolStructs.Deltas memory deltas = isPool0 ? cache.deltas0 : cache.deltas1;
+        CoverPoolStructs.Deltas memory deltas = isPool0 ? cache.deltas0 : cache.deltas1;
         emit StashDeltasAccumulated(
             deltas.amountInDelta,
             deltas.amountOutDelta,
@@ -641,7 +644,7 @@ library Epochs {
             isPool0
         );
         if (deltas.amountInDeltaMax > 0) {
-            (deltas, stashTick) = Deltas.stash(deltas, stashTick);
+            (deltas, stashTick) = Deltas.stash(deltas, stashTick, isPool0);
         }
         stashTick.liquidityDelta += int128(currentLiquidity);
         return (stashTick);

--- a/contracts/libraries/Epochs.sol
+++ b/contracts/libraries/Epochs.sol
@@ -201,9 +201,9 @@ library Epochs {
                 deltas: cache.deltas0,
                 crossTick: ticks[cache.nextTickToCross0],
                 accumTick: ticks[cache.nextTickToAccum0],
-                updateAccumDeltas: cache.newLatestTick > state.latestTick
-                                            ? cache.nextTickToAccum0 == cache.stopTick0
-                                            : cache.nextTickToAccum0 >= cache.stopTick0,
+                updateAccumDeltas: cache.newLatestTick > state.latestTick                // check twap move up or down
+                                            ? cache.nextTickToAccum0 == cache.stopTick0  // move up - true at stop tick
+                                            : cache.nextTickToAccum0 >= cache.stopTick0, // move down - at or above stop tick
                 isPool0: true
             });
             params = _accumulate(
@@ -267,9 +267,9 @@ library Epochs {
                     deltas: cache.deltas1,
                     crossTick: ticks[cache.nextTickToCross1],
                     accumTick: ticks[cache.nextTickToAccum1],
-                    updateAccumDeltas: cache.newLatestTick > state.latestTick
-                                                ? cache.nextTickToAccum1 <= cache.stopTick1
-                                                : cache.nextTickToAccum1 == cache.stopTick1,
+                    updateAccumDeltas: cache.newLatestTick > state.latestTick                   // check twap move up or down
+                                                ? cache.nextTickToAccum1 <= cache.stopTick1     // move up - below or at
+                                                : cache.nextTickToAccum1 == cache.stopTick1,    // move down - at
                     isPool0: false
                 });
                 params = _accumulate(
@@ -522,7 +522,8 @@ library Epochs {
     ) internal returns (
         CoverPoolStructs.AccumulateParams memory
     ) {
-        if (params.crossTick.amountInDeltaMaxStashed > 0) {
+        if (params.isPool0 == params.crossTick.pool0Stash &&
+                params.crossTick.amountInDeltaMaxStashed > 0) {
             /// @dev - else we migrate carry deltas onto cache
             // add carry amounts to cache
             (params.crossTick, params.deltas) = Deltas.unstash(params.crossTick, params.deltas, params.isPool0);

--- a/contracts/libraries/TickMap.sol
+++ b/contracts/libraries/TickMap.sol
@@ -1,14 +1,14 @@
 // SPDX-License-Identifier: BUSL-1.1
 pragma solidity ^0.8.13;
 
-import '../interfaces/ICoverPoolStructs.sol';
+import '../interfaces/structs/CoverPoolStructs.sol';
 import './math/ConstantProduct.sol';
 
 library TickMap {
     function set(
         int24 tick,
-        ICoverPoolStructs.TickMap storage tickMap,
-        ICoverPoolStructs.Immutables memory constants
+        CoverPoolStructs.TickMap storage tickMap,
+        CoverPoolStructs.Immutables memory constants
     ) external returns (
         bool exists
     )    
@@ -33,8 +33,8 @@ library TickMap {
 
     function unset(
         int24 tick,
-        ICoverPoolStructs.TickMap storage tickMap,
-        ICoverPoolStructs.Immutables memory constants
+        CoverPoolStructs.TickMap storage tickMap,
+        CoverPoolStructs.Immutables memory constants
     ) external {
         (
             uint256 tickIndex,
@@ -53,8 +53,8 @@ library TickMap {
 
     function previous(
         int24 tick,
-        ICoverPoolStructs.TickMap storage tickMap,
-        ICoverPoolStructs.Immutables memory constants
+        CoverPoolStructs.TickMap storage tickMap,
+        CoverPoolStructs.Immutables memory constants
     ) external view returns (
         int24 previousTick
     ) {
@@ -83,8 +83,8 @@ library TickMap {
 
     function next(
         int24 tick,
-        ICoverPoolStructs.TickMap storage tickMap,
-        ICoverPoolStructs.Immutables memory constants
+        CoverPoolStructs.TickMap storage tickMap,
+        CoverPoolStructs.Immutables memory constants
     ) external view returns (
         int24 nextTick
     ) {
@@ -118,7 +118,7 @@ library TickMap {
 
     function getIndices(
         int24 tick,
-        ICoverPoolStructs.Immutables memory constants
+        CoverPoolStructs.Immutables memory constants
     ) public pure returns (
             uint256 tickIndex,
             uint256 wordIndex,
@@ -138,7 +138,7 @@ library TickMap {
 
     function _tick (
         uint256 tickIndex,
-        ICoverPoolStructs.Immutables memory constants
+        CoverPoolStructs.Immutables memory constants
     ) internal pure returns (
         int24 tick
     ) {

--- a/contracts/libraries/math/ConstantProduct.sol
+++ b/contracts/libraries/math/ConstantProduct.sol
@@ -2,7 +2,7 @@
 pragma solidity 0.8.13;
 
 import './OverflowMath.sol';
-import '../../interfaces/ICoverPoolStructs.sol';
+import '../../interfaces/structs/CoverPoolStructs.sol';
 
 /// @notice Math library that facilitates ranged liquidity calculations.
 library ConstantProduct {
@@ -188,7 +188,7 @@ library ConstantProduct {
     ) internal pure returns (
         uint160 price
     ) {
-        ICoverPoolStructs.Immutables  memory constants;
+        CoverPoolStructs.Immutables  memory constants;
         constants.tickSpread = tickSpacing;
         return getPriceAtTick(minTick(tickSpacing), constants);
     }
@@ -198,7 +198,7 @@ library ConstantProduct {
     ) internal pure returns (
         uint160 price
     ) {
-        ICoverPoolStructs.Immutables  memory constants;
+        CoverPoolStructs.Immutables  memory constants;
         constants.tickSpread = tickSpacing;
         return getPriceAtTick(maxTick(tickSpacing), constants);
     }
@@ -230,7 +230,7 @@ library ConstantProduct {
     /// at the given tick.
     function getPriceAtTick(
         int24 tick,
-        ICoverPoolStructs.Immutables memory constants
+        CoverPoolStructs.Immutables memory constants
     ) internal pure returns (
         uint160 price
     ) {
@@ -273,7 +273,7 @@ library ConstantProduct {
     /// @return tick The greatest tick for which the ratio is less than or equal to the input ratio.
     function getTickAtPrice(
         uint160 price,
-        ICoverPoolStructs.Immutables  memory constants
+        CoverPoolStructs.Immutables  memory constants
     ) internal pure returns (int24 tick) {
         // Second inequality must be < because the price can never reach the price at the max tick.
         if (price < constants.bounds.min || price > constants.bounds.max)

--- a/contracts/libraries/pool/BurnCall.sol
+++ b/contracts/libraries/pool/BurnCall.sol
@@ -1,7 +1,7 @@
 // SPDX-License-Identifier: MIT
 pragma solidity ^0.8.13;
 
-import '../../interfaces/ICoverPoolStructs.sol';
+import '../../interfaces/structs/CoverPoolStructs.sol';
 import '../Positions.sol';
 import '../utils/Collect.sol';
 
@@ -25,12 +25,12 @@ library BurnCall {
 
     function perform(
         ICoverPool.BurnParams memory params,
-        ICoverPoolStructs.BurnCache memory cache,
-        ICoverPoolStructs.TickMap storage tickMap,
-        mapping(int24 => ICoverPoolStructs.Tick) storage ticks,
-        mapping(uint256 => ICoverPoolStructs.CoverPosition)
+        CoverPoolStructs.BurnCache memory cache,
+        CoverPoolStructs.TickMap storage tickMap,
+        mapping(int24 => CoverPoolStructs.Tick) storage ticks,
+        mapping(uint256 => CoverPoolStructs.CoverPosition)
             storage positions
-    ) external returns (ICoverPoolStructs.BurnCache memory) {
+    ) external returns (CoverPoolStructs.BurnCache memory) {
         cache.position = positions[params.positionId];
         if (cache.position.owner != msg.sender) {
             require(false, 'PositionNotFound()');
@@ -51,7 +51,7 @@ library BurnCall {
                     tickMap,
                     cache.state,
                     cache.pool0,
-                    ICoverPoolStructs.UpdateParams(
+                    CoverPoolStructs.UpdateParams(
                         msg.sender,
                         params.to,
                         params.burnPercent,
@@ -74,7 +74,7 @@ library BurnCall {
                     tickMap,
                     cache.state,
                     cache.pool1,
-                    ICoverPoolStructs.UpdateParams(
+                    CoverPoolStructs.UpdateParams(
                         msg.sender,
                         params.to,
                         params.burnPercent,
@@ -94,7 +94,7 @@ library BurnCall {
                 ticks,
                 tickMap,
                 cache.state,
-                ICoverPoolStructs.RemoveParams(
+                CoverPoolStructs.RemoveParams(
                     msg.sender,
                     params.to,
                     params.burnPercent,
@@ -109,7 +109,7 @@ library BurnCall {
         Collect.burn(
             cache,
             positions,
-            ICoverPoolStructs.CollectParams(
+            CoverPoolStructs.CollectParams(
                 cache.syncFees,
                 params.to, //address(0) goes to msg.sender
                 params.positionId,

--- a/contracts/libraries/pool/MintCall.sol
+++ b/contracts/libraries/pool/MintCall.sol
@@ -4,7 +4,6 @@ pragma solidity ^0.8.13;
 import '../../interfaces/structs/CoverPoolStructs.sol';
 import '../Positions.sol';
 import '../utils/Collect.sol';
-import 'hardhat/console.sol';
 
 library MintCall {
     event Mint(

--- a/contracts/libraries/pool/MintCall.sol
+++ b/contracts/libraries/pool/MintCall.sol
@@ -1,7 +1,7 @@
 // SPDX-License-Identifier: MIT
 pragma solidity ^0.8.13;
 
-import '../../interfaces/ICoverPoolStructs.sol';
+import '../../interfaces/structs/CoverPoolStructs.sol';
 import '../Positions.sol';
 import '../utils/Collect.sol';
 import 'hardhat/console.sol';
@@ -22,12 +22,12 @@ library MintCall {
 
     function perform(
         ICoverPool.MintParams memory params,
-        ICoverPoolStructs.MintCache memory cache,
-        ICoverPoolStructs.TickMap storage tickMap,
-        mapping(int24 => ICoverPoolStructs.Tick) storage ticks,
-        mapping(uint256 => ICoverPoolStructs.CoverPosition)
+        CoverPoolStructs.MintCache memory cache,
+        CoverPoolStructs.TickMap storage tickMap,
+        mapping(int24 => CoverPoolStructs.Tick) storage ticks,
+        mapping(uint256 => CoverPoolStructs.CoverPosition)
             storage positions
-    ) external returns (ICoverPoolStructs.MintCache memory) {
+    ) external returns (CoverPoolStructs.MintCache memory) {
         if (params.positionId > 0) {
             // load existing position
             cache.position = positions[params.positionId];
@@ -44,7 +44,7 @@ library MintCall {
         if (params.positionId == 0 ||                       // new position
                 params.lower != cache.position.lower ||     // lower mismatch
                 params.upper != cache.position.upper) {     // upper mismatch
-            ICoverPoolStructs.CoverPosition memory newPosition;
+            CoverPoolStructs.CoverPosition memory newPosition;
             newPosition.owner = params.to;
             newPosition.lower = params.lower;
             newPosition.upper = params.upper;
@@ -64,7 +64,7 @@ library MintCall {
             ticks,
             tickMap,
             cache.state,
-            ICoverPoolStructs.AddParams(
+            CoverPoolStructs.AddParams(
                 params.to,
                 uint128(cache.liquidityMinted),
                 params.amount,
@@ -77,7 +77,7 @@ library MintCall {
         );
         Collect.mint(
             cache,
-            ICoverPoolStructs.CollectParams(
+            CoverPoolStructs.CollectParams(
                 cache.syncFees,
                 params.to,
                 params.positionId,

--- a/contracts/libraries/pool/QuoteCall.sol
+++ b/contracts/libraries/pool/QuoteCall.sol
@@ -1,7 +1,7 @@
 // SPDX-License-Identifier: MIT
 pragma solidity ^0.8.13;
 
-import '../../interfaces/ICoverPoolStructs.sol';
+import '../../interfaces/structs/CoverPoolStructs.sol';
 import '../../interfaces/ICoverPool.sol';
 import '../Ticks.sol';
 
@@ -10,13 +10,13 @@ library QuoteCall {
 
     function perform(
         ICoverPool.QuoteParams memory params,
-        ICoverPoolStructs.SwapCache memory cache
+        CoverPoolStructs.SwapCache memory cache
     ) external view returns (
-        ICoverPoolStructs.SwapCache memory
+        CoverPoolStructs.SwapCache memory
     ) {
     {
-        ICoverPoolStructs.PoolState memory pool = params.zeroForOne ? cache.pool1 : cache.pool0;
-        cache = ICoverPoolStructs.SwapCache({
+        CoverPoolStructs.PoolState memory pool = params.zeroForOne ? cache.pool1 : cache.pool0;
+        cache = CoverPoolStructs.SwapCache({
             state: cache.state,
             syncFees: cache.syncFees,
             constants: cache.constants,

--- a/contracts/libraries/pool/SwapCall.sol
+++ b/contracts/libraries/pool/SwapCall.sol
@@ -1,7 +1,7 @@
 // SPDX-License-Identifier: MIT
 pragma solidity ^0.8.13;
 
-import '../../interfaces/ICoverPoolStructs.sol';
+import '../../interfaces/structs/CoverPoolStructs.sol';
 import '../../interfaces/IERC20Minimal.sol';
 import '../../interfaces/callbacks/ICoverPoolSwapCallback.sol';
 import '../Epochs.sol';
@@ -30,14 +30,14 @@ library SwapCall {
 
     function perform(
         ICoverPool.SwapParams memory params,
-        ICoverPoolStructs.SwapCache memory cache,
-        ICoverPoolStructs.GlobalState storage globalState,
-        ICoverPoolStructs.PoolState storage pool0,
-        ICoverPoolStructs.PoolState storage pool1
-    ) external returns (ICoverPoolStructs.SwapCache memory) {
+        CoverPoolStructs.SwapCache memory cache,
+        CoverPoolStructs.GlobalState storage globalState,
+        CoverPoolStructs.PoolState storage pool0,
+        CoverPoolStructs.PoolState storage pool1
+    ) external returns (CoverPoolStructs.SwapCache memory) {
         {
-            ICoverPoolStructs.PoolState memory pool = params.zeroForOne ? cache.pool1 : cache.pool0;
-            cache = ICoverPoolStructs.SwapCache({
+            CoverPoolStructs.PoolState memory pool = params.zeroForOne ? cache.pool1 : cache.pool0;
+            cache = CoverPoolStructs.SwapCache({
                 state: cache.state,
                 syncFees: cache.syncFees,
                 constants: cache.constants,
@@ -119,10 +119,10 @@ library SwapCall {
     }
 
     function save(
-        ICoverPoolStructs.SwapCache memory cache,
-        ICoverPoolStructs.GlobalState storage globalState,
-        ICoverPoolStructs.PoolState storage pool0,
-        ICoverPoolStructs.PoolState storage pool1
+        CoverPoolStructs.SwapCache memory cache,
+        CoverPoolStructs.GlobalState storage globalState,
+        CoverPoolStructs.PoolState storage pool0,
+        CoverPoolStructs.PoolState storage pool1
     ) internal {
         globalState.latestPrice = cache.state.latestPrice;
         globalState.liquidityGlobal = cache.state.liquidityGlobal;
@@ -146,7 +146,7 @@ library SwapCall {
 
     function balance(
         ICoverPool.SwapParams memory params,
-        ICoverPoolStructs.SwapCache memory cache
+        CoverPoolStructs.SwapCache memory cache
     ) private view returns (uint256) {
         (
             bool success,

--- a/contracts/libraries/sources/PoolsharkRangeSource.sol
+++ b/contracts/libraries/sources/PoolsharkRangeSource.sol
@@ -4,7 +4,7 @@ pragma solidity ^0.8.13;
 import '../../interfaces/external/poolshark/range/IRangePoolManager.sol';
 import '../../interfaces/external/poolshark/range/IRangePoolFactory.sol';
 import '../../interfaces/external/poolshark/range/IRangePool.sol';
-import '../../interfaces/ICoverPoolStructs.sol';
+import '../../interfaces/structs/CoverPoolStructs.sol';
 import '../../interfaces/modules/sources/ITwapSource.sol';
 import '../math/ConstantProduct.sol';
 
@@ -26,7 +26,7 @@ contract PoolsharkRangeSource is ITwapSource {
     }
 
     function initialize(
-        ICoverPoolStructs.Immutables memory constants
+        CoverPoolStructs.Immutables memory constants
     ) external returns (
         uint8 initializable,
         int24 startingTick
@@ -78,7 +78,7 @@ contract PoolsharkRangeSource is ITwapSource {
     }
 
     function calculateAverageTick(
-        ICoverPoolStructs.Immutables memory constants,
+        CoverPoolStructs.Immutables memory constants,
         int24 latestTick
     ) external view returns (
         int24 averageTick
@@ -98,7 +98,7 @@ contract PoolsharkRangeSource is ITwapSource {
     }
 
     function _calculateAverageTicks(
-        ICoverPoolStructs.Immutables memory constants
+        CoverPoolStructs.Immutables memory constants
     ) internal view returns (
         int24[4] memory averageTicks
     )

--- a/contracts/libraries/sources/UniswapV3Source.sol
+++ b/contracts/libraries/sources/UniswapV3Source.sol
@@ -3,7 +3,7 @@ pragma solidity ^0.8.13;
 
 import '../../interfaces/external/uniswap/v3/IUniswapV3Factory.sol';
 import '../../interfaces/external/uniswap/v3/IUniswapV3Pool.sol';
-import '../../interfaces/ICoverPoolStructs.sol';
+import '../../interfaces/structs/CoverPoolStructs.sol';
 import '../../interfaces/modules/sources/ITwapSource.sol';
 import '../math/ConstantProduct.sol';
 
@@ -21,7 +21,7 @@ contract UniswapV3Source is ITwapSource {
     }
 
     function initialize(
-        ICoverPoolStructs.Immutables memory constants
+        CoverPoolStructs.Immutables memory constants
     ) external returns (
         uint8 initializable,
         int24 startingTick
@@ -73,7 +73,7 @@ contract UniswapV3Source is ITwapSource {
     }
 
     function calculateAverageTick(
-        ICoverPoolStructs.Immutables memory constants,
+        CoverPoolStructs.Immutables memory constants,
         int24 latestTick
     ) external view returns (
         int24 averageTick
@@ -93,7 +93,7 @@ contract UniswapV3Source is ITwapSource {
     }
 
     function _calculateAverageTicks(
-        ICoverPoolStructs.Immutables memory constants
+        CoverPoolStructs.Immutables memory constants
     ) internal view returns (
         int24[4] memory averageTicks
     )

--- a/contracts/libraries/utils/Collect.sol
+++ b/contracts/libraries/utils/Collect.sol
@@ -1,15 +1,15 @@
 // SPDX-License-Identifier: MIT
 pragma solidity ^0.8.13;
 
-import '../../interfaces/ICoverPoolStructs.sol';
+import '../../interfaces/structs/CoverPoolStructs.sol';
 import '../Epochs.sol';
 import '../Positions.sol';
 import '../utils/SafeTransfers.sol';
 
 library Collect {
     function mint(
-        ICoverPoolStructs.MintCache memory cache,
-        ICoverPoolStructs.CollectParams memory params
+        CoverPoolStructs.MintCache memory cache,
+        CoverPoolStructs.CollectParams memory params
     ) internal {
         if (params.syncFees.token0 == 0 && params.syncFees.token1 == 0) return;
         // store amounts for transferOut
@@ -35,10 +35,10 @@ library Collect {
     }
 
     function burn(
-        ICoverPoolStructs.BurnCache memory cache,
-        mapping(uint256 => ICoverPoolStructs.CoverPosition)
+        CoverPoolStructs.BurnCache memory cache,
+        mapping(uint256 => CoverPoolStructs.CoverPosition)
             storage positions,
-        ICoverPoolStructs.CollectParams memory params
+        CoverPoolStructs.CollectParams memory params
         
     ) internal {
         params.zeroForOne ? params.upper = params.claim : params.lower = params.claim;

--- a/contracts/utils/PoolsharkRouter.sol
+++ b/contracts/utils/PoolsharkRouter.sol
@@ -10,7 +10,7 @@ import '../external/solady/LibClone.sol';
 
 contract PoolsharkRouter is
     ICoverPoolSwapCallback,
-    ICoverPoolStructs,
+    CoverPoolStructs,
     PoolsharkStructs
 {
     using SafeCast for uint256;
@@ -47,7 +47,7 @@ contract PoolsharkRouter is
         int256 amount1Delta,
         bytes calldata data
     ) external override {
-        ICoverPoolStructs.Immutables memory constants = ICoverPool(msg.sender).immutables();
+        CoverPoolStructs.Immutables memory constants = ICoverPool(msg.sender).immutables();
 
         // generate key for pool
         bytes32 key = keccak256(abi.encode(

--- a/test/contracts/coverpool.ts
+++ b/test/contracts/coverpool.ts
@@ -3581,7 +3581,6 @@ describe('CoverPool Tests', function () {
         await validateSync(20)
         await validateSync(40)
         await validateSync(60)
-        
 
         const aliceId = await validateMint({
             signer: hre.props.alice,
@@ -3598,10 +3597,10 @@ describe('CoverPool Tests', function () {
         })
 
         await validateSync(100)
-        await getTick(false, 100, true)
+        if (debugMode) await getTick(false, 100, true)
         await validateSync(60)
 
-        await getTick(false, 120, true)
+        if (debugMode) await getTick(false, 120, true)
 
         await validateBurn({
             signer: hre.props.alice,

--- a/test/contracts/coverpool.ts
+++ b/test/contracts/coverpool.ts
@@ -215,8 +215,8 @@ describe('CoverPool Tests', function () {
 
         if (deltaMaxBeforeCheck) {
             console.log('final tick')
-            console.log('deltainmax  before:', (await hre.props.coverPool.ticks0('-40')).amountInDeltaMaxMinus.toString())
-            console.log('deltaoutmax before:', (await hre.props.coverPool.ticks0('-40')).amountOutDeltaMaxMinus.toString())
+            console.log('deltainmax  before:', (await hre.props.coverPool.ticks('-40')).amountInDeltaMaxMinus.toString())
+            console.log('deltaoutmax before:', (await hre.props.coverPool.ticks('-40')).amountOutDeltaMaxMinus.toString())
         }
 
         // process two burns
@@ -242,8 +242,8 @@ describe('CoverPool Tests', function () {
         }
         if (deltaMaxAfterCheck) {
             console.log('final tick')
-            console.log('deltainmax  after:', (await hre.props.coverPool.ticks0('-40')).amountInDeltaMaxMinus.toString())
-            console.log('deltaoutmax after:', (await hre.props.coverPool.ticks0('-40')).amountOutDeltaMaxMinus.toString())
+            console.log('deltainmax  after:', (await hre.props.coverPool.ticks('-40')).amountInDeltaMaxMinus.toString())
+            console.log('deltaoutmax after:', (await hre.props.coverPool.ticks('-40')).amountOutDeltaMaxMinus.toString())
         }
     })
 
@@ -330,8 +330,8 @@ describe('CoverPool Tests', function () {
         }
         if (deltaMaxAfterCheck) {
             console.log('final tick')
-            console.log('deltainmax  after:', (await hre.props.coverPool.ticks0('-40')).amountInDeltaMaxMinus.toString())
-            console.log('deltaoutmax after:', (await hre.props.coverPool.ticks0('-40')).amountOutDeltaMaxMinus.toString())
+            console.log('deltainmax  after:', (await hre.props.coverPool.ticks('-40')).amountInDeltaMaxMinus.toString())
+            console.log('deltaoutmax after:', (await hre.props.coverPool.ticks('-40')).amountOutDeltaMaxMinus.toString())
         }
     })
 
@@ -417,8 +417,8 @@ describe('CoverPool Tests', function () {
         }
         if (deltaMaxAfterCheck) {
             console.log('final tick')
-            console.log('deltainmax  after:', (await hre.props.coverPool.ticks0('-40')).amountInDeltaMaxMinus.toString())
-            console.log('deltaoutmax after:', (await hre.props.coverPool.ticks0('-40')).amountOutDeltaMaxMinus.toString())
+            console.log('deltainmax  after:', (await hre.props.coverPool.ticks('-40')).amountInDeltaMaxMinus.toString())
+            console.log('deltaoutmax after:', (await hre.props.coverPool.ticks('-40')).amountOutDeltaMaxMinus.toString())
         }
     })
 
@@ -490,8 +490,8 @@ describe('CoverPool Tests', function () {
         }
         if (deltaMaxAfterCheck) {
             console.log('final tick')
-            console.log('deltainmax  after:', (await hre.props.coverPool.ticks0('-40')).amountInDeltaMaxMinus.toString())
-            console.log('deltaoutmax after:', (await hre.props.coverPool.ticks0('-40')).amountOutDeltaMaxMinus.toString())
+            console.log('deltainmax  after:', (await hre.props.coverPool.ticks('-40')).amountInDeltaMaxMinus.toString())
+            console.log('deltaoutmax after:', (await hre.props.coverPool.ticks('-40')).amountOutDeltaMaxMinus.toString())
         }
     })
 
@@ -548,8 +548,8 @@ describe('CoverPool Tests', function () {
         }
         if (deltaMaxAfterCheck) {
             console.log('final tick')
-            console.log('deltainmax  after:', (await hre.props.coverPool.ticks0('-60')).amountInDeltaMaxMinus.toString())
-            console.log('deltaoutmax after:', (await hre.props.coverPool.ticks0('-60')).amountOutDeltaMaxMinus.toString())
+            console.log('deltainmax  after:', (await hre.props.coverPool.ticks('-60')).amountInDeltaMaxMinus.toString())
+            console.log('deltaoutmax after:', (await hre.props.coverPool.ticks('-60')).amountOutDeltaMaxMinus.toString())
         }
 
         await validateSync(0)
@@ -635,11 +635,11 @@ describe('CoverPool Tests', function () {
         }
         if (deltaMaxAfterCheck) {
             console.log('claim tick')
-            console.log('deltainmax  after:', (await hre.props.coverPool.ticks0('-20')).amountInDeltaMaxMinus.toString())
-            console.log('deltaoutmax after:', (await hre.props.coverPool.ticks0('-20')).amountOutDeltaMaxMinus.toString())
+            console.log('deltainmax  after:', (await hre.props.coverPool.ticks('-20')).amountInDeltaMaxMinus.toString())
+            console.log('deltaoutmax after:', (await hre.props.coverPool.ticks('-20')).amountOutDeltaMaxMinus.toString())
             console.log('final tick')
-            console.log('deltainmax  after:', (await hre.props.coverPool.ticks0('-40')).amountInDeltaMaxMinus.toString())
-            console.log('deltaoutmax after:', (await hre.props.coverPool.ticks0('-40')).amountOutDeltaMaxMinus.toString())
+            console.log('deltainmax  after:', (await hre.props.coverPool.ticks('-40')).amountInDeltaMaxMinus.toString())
+            console.log('deltaoutmax after:', (await hre.props.coverPool.ticks('-40')).amountOutDeltaMaxMinus.toString())
         }
     })
 
@@ -715,11 +715,11 @@ describe('CoverPool Tests', function () {
         }
         if (deltaMaxAfterCheck) {
             console.log('claim tick')
-            console.log('deltainmax  after:', (await hre.props.coverPool.ticks0('78260')).amountInDeltaMaxMinus.toString())
-            console.log('deltaoutmax after:', (await hre.props.coverPool.ticks0('78260')).amountOutDeltaMaxMinus.toString())
+            console.log('deltainmax  after:', (await hre.props.coverPool.ticks('78260')).amountInDeltaMaxMinus.toString())
+            console.log('deltaoutmax after:', (await hre.props.coverPool.ticks('78260')).amountOutDeltaMaxMinus.toString())
             console.log('final tick')
-            console.log('deltainmax  after:', (await hre.props.coverPool.ticks0('78260')).toString())
-            console.log('deltaoutmax after:', (await hre.props.coverPool.ticks0('78280')).toString())
+            console.log('deltainmax  after:', (await hre.props.coverPool.ticks('78260')).toString())
+            console.log('deltaoutmax after:', (await hre.props.coverPool.ticks('78280')).toString())
         }
     })
 
@@ -813,8 +813,8 @@ describe('CoverPool Tests', function () {
         }
         if (deltaMaxAfterCheck) {
             console.log('final tick')
-            console.log('deltainmax  after:', (await hre.props.coverPool.ticks0('-60')).amountInDeltaMaxMinus.toString())
-            console.log('deltaoutmax after:', (await hre.props.coverPool.ticks0('-60')).amountOutDeltaMaxMinus.toString())
+            console.log('deltainmax  after:', (await hre.props.coverPool.ticks('-60')).amountInDeltaMaxMinus.toString())
+            console.log('deltaoutmax after:', (await hre.props.coverPool.ticks('-60')).amountOutDeltaMaxMinus.toString())
         }
     })
 
@@ -1163,12 +1163,12 @@ describe('CoverPool Tests', function () {
         // Price goes into Alice's position
         await validateSync(0);
 
-        let upperTick = await hre.props.coverPool.ticks0(0);
+        let upperTick = await hre.props.coverPool.ticks(0);
         expect(upperTick.liquidityDelta).to.eq("33285024970969944913475");
 
         // After going down to -20, tick 0 will be the cross tick and the liquidityDelta will be cleared
         await validateSync(-20);
-        upperTick = await hre.props.coverPool.ticks0(0);
+        upperTick = await hre.props.coverPool.ticks(0);
         expect(upperTick.liquidityDelta).to.eq("0");
 
         // Pool has active liquidity once tick0 is crossed.
@@ -1442,11 +1442,11 @@ describe('CoverPool Tests', function () {
         // his position is fully filled.
         if (deltaMaxAfterCheck) {
             console.log('claim tick')
-            console.log('deltainmax  after:', (await hre.props.coverPool.ticks0('-20')).amountInDeltaMaxStashed.toString())
-            console.log('deltaoutmax after:', (await hre.props.coverPool.ticks0('-20')).amountOutDeltaMaxStashed.toString())
+            console.log('deltainmax  after:', (await hre.props.coverPool.ticks('-20')).amountInDeltaMaxStashed.toString())
+            console.log('deltaoutmax after:', (await hre.props.coverPool.ticks('-20')).amountOutDeltaMaxStashed.toString())
             console.log('final tick')
-            console.log('deltainmax  after:', (await hre.props.coverPool.ticks0('-80')).amountInDeltaMaxMinus.toString())
-            console.log('deltaoutmax after:', (await hre.props.coverPool.ticks0('-80')).amountOutDeltaMaxMinus.toString())
+            console.log('deltainmax  after:', (await hre.props.coverPool.ticks('-80')).amountInDeltaMaxMinus.toString())
+            console.log('deltaoutmax after:', (await hre.props.coverPool.ticks('-80')).amountOutDeltaMaxMinus.toString())
         }
 
         await validateBurn({
@@ -1485,11 +1485,11 @@ describe('CoverPool Tests', function () {
         }
         if (deltaMaxAfterCheck) {
             console.log('claim tick')
-            console.log('deltainmax  after:', (await hre.props.coverPool.ticks0('-20')).amountInDeltaMaxStashed.toString())
-            console.log('deltaoutmax after:', (await hre.props.coverPool.ticks0('-20')).amountOutDeltaMaxStashed.toString())
+            console.log('deltainmax  after:', (await hre.props.coverPool.ticks('-20')).amountInDeltaMaxStashed.toString())
+            console.log('deltaoutmax after:', (await hre.props.coverPool.ticks('-20')).amountOutDeltaMaxStashed.toString())
             console.log('final tick')
-            console.log('deltainmax  after:', (await hre.props.coverPool.ticks0('-80')).amountInDeltaMaxMinus.toString())
-            console.log('deltaoutmax after:', (await hre.props.coverPool.ticks0('-80')).amountOutDeltaMaxMinus.toString())
+            console.log('deltainmax  after:', (await hre.props.coverPool.ticks('-80')).amountInDeltaMaxMinus.toString())
+            console.log('deltaoutmax after:', (await hre.props.coverPool.ticks('-80')).amountOutDeltaMaxMinus.toString())
         }
 
     });
@@ -2015,11 +2015,11 @@ describe('CoverPool Tests', function () {
 
         if (deltaMaxAfterCheck) {
             console.log('claim tick')
-            console.log('deltainmax  after:', (await hre.props.coverPool.ticks0('-20')).amountInDeltaMaxStashed.toString())
-            console.log('deltaoutmax after:', (await hre.props.coverPool.ticks0('-20')).amountOutDeltaMaxStashed.toString())
+            console.log('deltainmax  after:', (await hre.props.coverPool.ticks('-20')).amountInDeltaMaxStashed.toString())
+            console.log('deltaoutmax after:', (await hre.props.coverPool.ticks('-20')).amountOutDeltaMaxStashed.toString())
             console.log('final tick')
-            console.log('deltainmax  after:', (await hre.props.coverPool.ticks0('-80')).amountInDeltaMaxMinus.toString())
-            console.log('deltaoutmax after:', (await hre.props.coverPool.ticks0('-80')).amountOutDeltaMaxMinus.toString())
+            console.log('deltainmax  after:', (await hre.props.coverPool.ticks('-80')).amountInDeltaMaxMinus.toString())
+            console.log('deltaoutmax after:', (await hre.props.coverPool.ticks('-80')).amountOutDeltaMaxMinus.toString())
         }
  
         await validateBurn({
@@ -2076,11 +2076,11 @@ describe('CoverPool Tests', function () {
 
         if (deltaMaxAfterCheck) {
             console.log('claim tick')
-            console.log('deltainmax  after:', (await hre.props.coverPool.ticks0('-20')).amountInDeltaMaxStashed.toString())
-            console.log('deltaoutmax after:', (await hre.props.coverPool.ticks0('-20')).amountOutDeltaMaxStashed.toString())
+            console.log('deltainmax  after:', (await hre.props.coverPool.ticks('-20')).amountInDeltaMaxStashed.toString())
+            console.log('deltaoutmax after:', (await hre.props.coverPool.ticks('-20')).amountOutDeltaMaxStashed.toString())
             console.log('final tick')
-            console.log('deltainmax  after:', (await hre.props.coverPool.ticks0('-80')).amountInDeltaMaxMinus.toString())
-            console.log('deltaoutmax after:', (await hre.props.coverPool.ticks0('-80')).amountOutDeltaMaxMinus.toString())
+            console.log('deltainmax  after:', (await hre.props.coverPool.ticks('-80')).amountInDeltaMaxMinus.toString())
+            console.log('deltaoutmax after:', (await hre.props.coverPool.ticks('-80')).amountOutDeltaMaxMinus.toString())
         }
     });
 
@@ -2270,11 +2270,11 @@ describe('CoverPool Tests', function () {
         }
         if (deltaMaxAfterCheck) {
             console.log('claim tick')
-            console.log('deltainmax  after:', (await hre.props.coverPool.ticks0('-40')).amountInDeltaMaxMinus.toString())
-            console.log('deltaoutmax after:', (await hre.props.coverPool.ticks0('-40')).amountOutDeltaMaxMinus.toString())
+            console.log('deltainmax  after:', (await hre.props.coverPool.ticks('-40')).amountInDeltaMaxMinus.toString())
+            console.log('deltaoutmax after:', (await hre.props.coverPool.ticks('-40')).amountOutDeltaMaxMinus.toString())
             console.log('final tick')
-            console.log('deltainmax  after:', (await hre.props.coverPool.ticks0('-60')).amountInDeltaMaxMinus.toString())
-            console.log('deltaoutmax after:', (await hre.props.coverPool.ticks0('-60')).amountOutDeltaMaxMinus.toString())
+            console.log('deltainmax  after:', (await hre.props.coverPool.ticks('-60')).amountInDeltaMaxMinus.toString())
+            console.log('deltaoutmax after:', (await hre.props.coverPool.ticks('-60')).amountOutDeltaMaxMinus.toString())
         }
     })
 
@@ -2338,8 +2338,8 @@ describe('CoverPool Tests', function () {
         }
         if (deltaMaxAfterCheck) {
             console.log('final tick')
-            console.log('deltainmax  after:', (await hre.props.coverPool.ticks0('-120')).amountInDeltaMaxMinus.toString())
-            console.log('deltaoutmax after:', (await hre.props.coverPool.ticks0('-120')).amountOutDeltaMaxMinus.toString())
+            console.log('deltainmax  after:', (await hre.props.coverPool.ticks('-120')).amountInDeltaMaxMinus.toString())
+            console.log('deltaoutmax after:', (await hre.props.coverPool.ticks('-120')).amountOutDeltaMaxMinus.toString())
         }
     })
 
@@ -2455,8 +2455,8 @@ describe('CoverPool Tests', function () {
         }
         if (deltaMaxAfterCheck) {
             console.log('final tick')
-            console.log('deltainmax  after:', (await hre.props.coverPool.ticks0('-120')).amountInDeltaMaxMinus.toString())
-            console.log('deltaoutmax after:', (await hre.props.coverPool.ticks0('-120')).amountOutDeltaMaxMinus.toString())
+            console.log('deltainmax  after:', (await hre.props.coverPool.ticks('-120')).amountInDeltaMaxMinus.toString())
+            console.log('deltaoutmax after:', (await hre.props.coverPool.ticks('-120')).amountOutDeltaMaxMinus.toString())
         }
     })
 
@@ -2543,8 +2543,8 @@ describe('CoverPool Tests', function () {
         }
         if (deltaMaxAfterCheck) {
             console.log('final tick')
-            console.log('deltainmax  after:', (await hre.props.coverPool.ticks0('-120')).amountInDeltaMaxMinus.toString())
-            console.log('deltaoutmax after:', (await hre.props.coverPool.ticks0('-120')).amountOutDeltaMaxMinus.toString())
+            console.log('deltainmax  after:', (await hre.props.coverPool.ticks('-120')).amountInDeltaMaxMinus.toString())
+            console.log('deltaoutmax after:', (await hre.props.coverPool.ticks('-120')).amountOutDeltaMaxMinus.toString())
         }
     })
 
@@ -2643,8 +2643,8 @@ describe('CoverPool Tests', function () {
         }
         if (deltaMaxAfterCheck) {
             console.log('final tick')
-            console.log('deltainmax  after:', (await hre.props.coverPool.ticks0('-60')).amountInDeltaMaxMinus.toString())
-            console.log('deltaoutmax after:', (await hre.props.coverPool.ticks0('-60')).amountOutDeltaMaxMinus.toString())
+            console.log('deltainmax  after:', (await hre.props.coverPool.ticks('-60')).amountInDeltaMaxMinus.toString())
+            console.log('deltaoutmax after:', (await hre.props.coverPool.ticks('-60')).amountOutDeltaMaxMinus.toString())
         }
     })
 
@@ -2722,8 +2722,8 @@ describe('CoverPool Tests', function () {
         }
         if (deltaMaxAfterCheck) {
             console.log('final tick')
-            console.log('deltainmax  after:', (await hre.props.coverPool.ticks0('-60')).amountInDeltaMaxMinus.toString())
-            console.log('deltaoutmax after:', (await hre.props.coverPool.ticks0('-60')).amountOutDeltaMaxMinus.toString())
+            console.log('deltainmax  after:', (await hre.props.coverPool.ticks('-60')).amountInDeltaMaxMinus.toString())
+            console.log('deltaoutmax after:', (await hre.props.coverPool.ticks('-60')).amountOutDeltaMaxMinus.toString())
         }
     })
 
@@ -2881,11 +2881,11 @@ describe('CoverPool Tests', function () {
         }
         if (deltaMaxAfterCheck) {
             console.log('claim tick')
-            console.log('deltainmax  after:', (await hre.props.coverPool.ticks0('-60')).amountInDeltaMaxMinus.toString())
-            console.log('deltaoutmax after:', (await hre.props.coverPool.ticks0('-60')).amountOutDeltaMaxMinus.toString())
+            console.log('deltainmax  after:', (await hre.props.coverPool.ticks('-60')).amountInDeltaMaxMinus.toString())
+            console.log('deltaoutmax after:', (await hre.props.coverPool.ticks('-60')).amountOutDeltaMaxMinus.toString())
             console.log('final tick')
-            console.log('deltainmax  after:', (await hre.props.coverPool.ticks0('-60')).amountInDeltaMaxMinus.toString())
-            console.log('deltaoutmax after:', (await hre.props.coverPool.ticks0('-60')).amountOutDeltaMaxMinus.toString())
+            console.log('deltainmax  after:', (await hre.props.coverPool.ticks('-60')).amountInDeltaMaxMinus.toString())
+            console.log('deltaoutmax after:', (await hre.props.coverPool.ticks('-60')).amountOutDeltaMaxMinus.toString())
         }
     })
 
@@ -2931,11 +2931,11 @@ describe('CoverPool Tests', function () {
         }
         if (deltaMaxAfterCheck) {
             console.log('claim tick')
-            console.log('deltainmax  after:', (await hre.props.coverPool.ticks0('-60')).amountInDeltaMaxMinus.toString())
-            console.log('deltaoutmax after:', (await hre.props.coverPool.ticks0('-60')).amountOutDeltaMaxMinus.toString())
+            console.log('deltainmax  after:', (await hre.props.coverPool.ticks('-60')).amountInDeltaMaxMinus.toString())
+            console.log('deltaoutmax after:', (await hre.props.coverPool.ticks('-60')).amountOutDeltaMaxMinus.toString())
             console.log('final tick')
-            console.log('deltainmax  after:', (await hre.props.coverPool.ticks0('-60')).amountInDeltaMaxMinus.toString())
-            console.log('deltaoutmax after:', (await hre.props.coverPool.ticks0('-60')).amountOutDeltaMaxMinus.toString())
+            console.log('deltainmax  after:', (await hre.props.coverPool.ticks('-60')).amountInDeltaMaxMinus.toString())
+            console.log('deltaoutmax after:', (await hre.props.coverPool.ticks('-60')).amountOutDeltaMaxMinus.toString())
         }        
     })
 
@@ -3020,11 +3020,11 @@ describe('CoverPool Tests', function () {
         }
         if (deltaMaxAfterCheck) {
             console.log('claim tick')
-            console.log('deltainmax  after:', (await hre.props.coverPool.ticks0('-60')).amountInDeltaMaxMinus.toString())
-            console.log('deltaoutmax after:', (await hre.props.coverPool.ticks0('-60')).amountOutDeltaMaxMinus.toString())
+            console.log('deltainmax  after:', (await hre.props.coverPool.ticks('-60')).amountInDeltaMaxMinus.toString())
+            console.log('deltaoutmax after:', (await hre.props.coverPool.ticks('-60')).amountOutDeltaMaxMinus.toString())
             console.log('final tick')
-            console.log('deltainmax  after:', (await hre.props.coverPool.ticks0('-60')).amountInDeltaMaxMinus.toString())
-            console.log('deltaoutmax after:', (await hre.props.coverPool.ticks0('-60')).amountOutDeltaMaxMinus.toString())
+            console.log('deltainmax  after:', (await hre.props.coverPool.ticks('-60')).amountInDeltaMaxMinus.toString())
+            console.log('deltaoutmax after:', (await hre.props.coverPool.ticks('-60')).amountOutDeltaMaxMinus.toString())
         } 
     })    
     // move TWAP in range; no-op swap; burn immediately
@@ -3105,8 +3105,8 @@ describe('CoverPool Tests', function () {
 
         if (deltaMaxAfterCheck) {
             console.log('final tick')
-            console.log('deltainmax  after:', (await hre.props.coverPool.ticks1('40')).amountInDeltaMaxMinus.toString())
-            console.log('deltaoutmax after:', (await hre.props.coverPool.ticks1('40')).amountOutDeltaMaxMinus.toString())
+            console.log('deltainmax  after:', (await hre.props.coverPool.ticks('40')).amountInDeltaMaxMinus.toString())
+            console.log('deltaoutmax after:', (await hre.props.coverPool.ticks('40')).amountOutDeltaMaxMinus.toString())
         }
     })
 
@@ -3156,8 +3156,8 @@ describe('CoverPool Tests', function () {
 
         if (deltaMaxAfterCheck) {
             console.log('final tick')
-            console.log('deltainmax  after:', (await hre.props.coverPool.ticks1('40')).amountInDeltaMaxMinus.toString())
-            console.log('deltaoutmax after:', (await hre.props.coverPool.ticks1('40')).amountOutDeltaMaxMinus.toString())
+            console.log('deltainmax  after:', (await hre.props.coverPool.ticks('40')).amountInDeltaMaxMinus.toString())
+            console.log('deltaoutmax after:', (await hre.props.coverPool.ticks('40')).amountOutDeltaMaxMinus.toString())
         }
     })
 
@@ -3249,8 +3249,8 @@ describe('CoverPool Tests', function () {
 
         if (deltaMaxAfterCheck) {
             console.log('final tick')
-            console.log('deltainmax  after:', (await hre.props.coverPool.ticks1('20')).amountInDeltaMaxMinus.toString())
-            console.log('deltaoutmax after:', (await hre.props.coverPool.ticks1('20')).amountOutDeltaMaxMinus.toString())
+            console.log('deltainmax  after:', (await hre.props.coverPool.ticks('20')).amountInDeltaMaxMinus.toString())
+            console.log('deltaoutmax after:', (await hre.props.coverPool.ticks('20')).amountOutDeltaMaxMinus.toString())
         }
     })
 
@@ -3358,8 +3358,8 @@ describe('CoverPool Tests', function () {
 
         if (deltaMaxAfterCheck) {
             console.log('final tick')
-            console.log('deltainmax  after:', (await hre.props.coverPool.ticks1('40')).amountInDeltaMaxMinus.toString())
-            console.log('deltaoutmax after:', (await hre.props.coverPool.ticks1('40')).amountOutDeltaMaxMinus.toString())
+            console.log('deltainmax  after:', (await hre.props.coverPool.ticks('40')).amountInDeltaMaxMinus.toString())
+            console.log('deltaoutmax after:', (await hre.props.coverPool.ticks('40')).amountOutDeltaMaxMinus.toString())
         }
     })
 
@@ -3412,8 +3412,8 @@ describe('CoverPool Tests', function () {
 
         if (deltaMaxAfterCheck) {
             console.log('final tick')
-            console.log('deltainmax  after:', (await hre.props.coverPool.ticks1('60')).amountInDeltaMaxMinus.toString())
-            console.log('deltaoutmax after:', (await hre.props.coverPool.ticks1('60')).amountOutDeltaMaxMinus.toString())
+            console.log('deltainmax  after:', (await hre.props.coverPool.ticks('60')).amountInDeltaMaxMinus.toString())
+            console.log('deltaoutmax after:', (await hre.props.coverPool.ticks('60')).amountOutDeltaMaxMinus.toString())
         }
     })
 
@@ -3459,8 +3459,8 @@ describe('CoverPool Tests', function () {
 
         if (deltaMaxAfterCheck) {
             console.log('final tick')
-            console.log('deltainmax  after:', (await hre.props.coverPool.ticks1('60')).amountInDeltaMaxMinus.toString())
-            console.log('deltaoutmax after:', (await hre.props.coverPool.ticks1('60')).amountOutDeltaMaxMinus.toString())
+            console.log('deltainmax  after:', (await hre.props.coverPool.ticks('60')).amountInDeltaMaxMinus.toString())
+            console.log('deltaoutmax after:', (await hre.props.coverPool.ticks('60')).amountOutDeltaMaxMinus.toString())
         }
     })
 
@@ -3521,8 +3521,8 @@ describe('CoverPool Tests', function () {
 
         if (deltaMaxAfterCheck) {
             console.log('final tick')
-            console.log('deltainmax  after:', (await hre.props.coverPool.ticks1('600020')).amountInDeltaMaxMinus.toString())
-            console.log('deltaoutmax after:', (await hre.props.coverPool.ticks1('600020')).amountOutDeltaMaxMinus.toString())
+            console.log('deltainmax  after:', (await hre.props.coverPool.ticks('600020')).amountInDeltaMaxMinus.toString())
+            console.log('deltaoutmax after:', (await hre.props.coverPool.ticks('600020')).amountOutDeltaMaxMinus.toString())
         }
     })
 
@@ -3567,11 +3567,11 @@ describe('CoverPool Tests', function () {
 
         if (deltaMaxAfterCheck) {
             console.log('claim tick')
-            console.log('deltainmax  after:', (await hre.props.coverPool.ticks1('100')).amountInDeltaMaxMinus.toString())
-            console.log('deltaoutmax after:', (await hre.props.coverPool.ticks1('100')).amountOutDeltaMaxMinus.toString())
+            console.log('deltainmax  after:', (await hre.props.coverPool.ticks('100')).amountInDeltaMaxMinus.toString())
+            console.log('deltaoutmax after:', (await hre.props.coverPool.ticks('100')).amountOutDeltaMaxMinus.toString())
             console.log('final tick')
-            console.log('deltainmax  after:', (await hre.props.coverPool.ticks1('120')).amountInDeltaMaxMinus.toString())
-            console.log('deltaoutmax after:', (await hre.props.coverPool.ticks1('120')).amountOutDeltaMaxMinus.toString())
+            console.log('deltainmax  after:', (await hre.props.coverPool.ticks('120')).amountInDeltaMaxMinus.toString())
+            console.log('deltaoutmax after:', (await hre.props.coverPool.ticks('120')).amountOutDeltaMaxMinus.toString())
         }
     })
 
@@ -3598,8 +3598,10 @@ describe('CoverPool Tests', function () {
         })
 
         await validateSync(100)
-
+        await getTick(false, 100, true)
         await validateSync(60)
+
+        await getTick(false, 120, true)
 
         await validateBurn({
             signer: hre.props.alice,
@@ -3620,8 +3622,8 @@ describe('CoverPool Tests', function () {
 
         if (deltaMaxAfterCheck) {
             console.log('final tick')
-            console.log('deltainmax  after:', (await hre.props.coverPool.ticks1('120')).amountInDeltaMaxMinus.toString())
-            console.log('deltaoutmax after:', (await hre.props.coverPool.ticks1('120')).amountOutDeltaMaxMinus.toString())
+            console.log('deltainmax  after:', (await hre.props.coverPool.ticks('120')).amountInDeltaMaxMinus.toString())
+            console.log('deltaoutmax after:', (await hre.props.coverPool.ticks('120')).amountOutDeltaMaxMinus.toString())
         }
     })
 

--- a/test/utils/contracts/coverpool.ts
+++ b/test/utils/contracts/coverpool.ts
@@ -68,7 +68,8 @@ export interface Tick {
     liquidityDelta: BigNumber
     amountInDeltaMaxStashed: BigNumber
     amountOutDeltaMaxStashed: BigNumber
-    deltas: Deltas
+    deltas0: Deltas
+    deltas1: Deltas
 }
 
 export interface Deltas {
@@ -158,8 +159,8 @@ export async function getPrice(isPool0: boolean, print: boolean = false): Promis
 }
 
 export async function getTick(isPool0: boolean, tickIndex: number, print: boolean = false): Promise<Tick> {
-    let tick: Tick = isPool0 ? (await hre.props.coverPool.ticks0(tickIndex))
-                             : (await hre.props.coverPool.ticks1(tickIndex));
+    let tick: Tick = isPool0 ? (await hre.props.coverPool.ticks(tickIndex))
+                             : (await hre.props.coverPool.ticks(tickIndex));
     if (print) {
         console.log(tickIndex,'tick:', tick.toString())
     }
@@ -395,14 +396,14 @@ export async function validateMint(params: ValidateMintParams): Promise<number> 
     let upperTickBefore: Tick
     let positionBefore: Position
     if (zeroForOne) {
-        lowerTickBefore = await hre.props.coverPool.ticks0(lower)
-        upperTickBefore = await hre.props.coverPool.ticks0(expectedUpper ? expectedUpper : upper)
+        lowerTickBefore = await hre.props.coverPool.ticks(lower)
+        upperTickBefore = await hre.props.coverPool.ticks(expectedUpper ? expectedUpper : upper)
         positionBefore  = await hre.props.coverPool.positions0(
             expectedPositionId
         )
     } else {
-        lowerTickBefore = await hre.props.coverPool.ticks1(expectedLower ? expectedLower : lower)
-        upperTickBefore = await hre.props.coverPool.ticks1(upper)
+        lowerTickBefore = await hre.props.coverPool.ticks(expectedLower ? expectedLower : lower)
+        upperTickBefore = await hre.props.coverPool.ticks(upper)
         positionBefore  = await hre.props.coverPool.positions1(
             expectedPositionId
         )
@@ -454,14 +455,14 @@ export async function validateMint(params: ValidateMintParams): Promise<number> 
     let upperTickAfter: Tick
     let positionAfter: Position
     if (zeroForOne) {
-        lowerTickAfter = await hre.props.coverPool.ticks0(lower)
-        upperTickAfter = await hre.props.coverPool.ticks0(expectedUpper ? expectedUpper : upper)
+        lowerTickAfter = await hre.props.coverPool.ticks(lower)
+        upperTickAfter = await hre.props.coverPool.ticks(expectedUpper ? expectedUpper : upper)
         positionAfter = await hre.props.coverPool.positions0(
             expectedPositionId
         )
     } else {
-        lowerTickAfter = await hre.props.coverPool.ticks1(expectedLower ? expectedLower : lower)
-        upperTickAfter = await hre.props.coverPool.ticks1(upper)
+        lowerTickAfter = await hre.props.coverPool.ticks(expectedLower ? expectedLower : lower)
+        upperTickAfter = await hre.props.coverPool.ticks(upper)
         positionAfter = await hre.props.coverPool.positions1(
             expectedPositionId
         )
@@ -543,12 +544,12 @@ export async function validateBurn(params: ValidateBurnParams) {
     let positionSnapshot: Position
 
     if (zeroForOne) {
-        lowerTickBefore = await hre.props.coverPool.ticks0(lower)
-        upperTickBefore = await hre.props.coverPool.ticks0(upper)
+        lowerTickBefore = await hre.props.coverPool.ticks(lower)
+        upperTickBefore = await hre.props.coverPool.ticks(upper)
         positionBefore = await hre.props.coverPool.positions0(positionId)
     } else {
-        lowerTickBefore = await hre.props.coverPool.ticks1(lower)
-        upperTickBefore = await hre.props.coverPool.ticks1(upper)
+        lowerTickBefore = await hre.props.coverPool.ticks(lower)
+        upperTickBefore = await hre.props.coverPool.ticks(upper)
         positionBefore = await hre.props.coverPool.positions1(positionId)
     }
 
@@ -623,12 +624,12 @@ export async function validateBurn(params: ValidateBurnParams) {
     let positionAfter: Position
 
     if (zeroForOne) {
-        lowerTickAfter = await hre.props.coverPool.ticks0(lower)
-        upperTickAfter = await hre.props.coverPool.ticks0(upper)
+        lowerTickAfter = await hre.props.coverPool.ticks(lower)
+        upperTickAfter = await hre.props.coverPool.ticks(upper)
         positionAfter = await hre.props.coverPool.positions0(positionId)
     } else {
-        lowerTickAfter = await hre.props.coverPool.ticks1(lower)
-        upperTickAfter = await hre.props.coverPool.ticks1(upper)
+        lowerTickAfter = await hre.props.coverPool.ticks(lower)
+        upperTickAfter = await hre.props.coverPool.ticks(upper)
         positionAfter = await hre.props.coverPool.positions1(positionId)
     }
     //dependent on zeroForOne


### PR DESCRIPTION
This PR handles ticks being unset because the values are one side (i.e. either pool0 or pool1) are empty which could result in errantly deleting a tick from the mapping when there is still liquidity on the other side.

In order for us to know which pool's liquidity is stashed on a given tick, we use the `pool0Stashed` flag within the `Tick` struct.

Instead of having two different sets of ticks with two different `Deltas` struct, we now have a single tick mapping with `deltas0` and `deltas1`.

This required minimal code changes since the file `Deltas.sol` abstracts away all `Deltas` struct operations.