### PR TITLE
`epochs0` and `epochs1`

### DIFF
--- a/contracts/interfaces/structs/CoverPoolStructs.sol
+++ b/contracts/interfaces/structs/CoverPoolStructs.sol
@@ -30,7 +30,8 @@ interface CoverPoolStructs {
         uint256 blocks;                     /// @dev - sets of words
         mapping(uint256 => uint256) words;  /// @dev - sets to words
         mapping(uint256 => uint256) ticks;  /// @dev - words to ticks
-        mapping(uint256 => mapping(uint256 => mapping(uint256 => uint256))) epochs; /// @dev - ticks to epochs
+        mapping(uint256 => mapping(uint256 => mapping(uint256 => uint256))) epochs0; /// @dev - ticks to pool0 epochs
+        mapping(uint256 => mapping(uint256 => mapping(uint256 => uint256))) epochs1; /// @dev - ticks to pool1 epochs
     }
 
     struct Tick {

--- a/contracts/libraries/Claims.sol
+++ b/contracts/libraries/Claims.sol
@@ -27,9 +27,9 @@ library Claims {
         }
         // if the position has not been crossed into at all
         else if (params.zeroForOne ? params.claim == params.upper 
-                                        && EpochMap.get(params.upper, tickMap, constants) <= cache.position.accumEpochLast
+                                        && EpochMap.get(params.upper, params.zeroForOne, tickMap, constants) <= cache.position.accumEpochLast
                                      : params.claim == params.lower 
-                                        && EpochMap.get(params.lower, tickMap, constants) <= cache.position.accumEpochLast
+                                        && EpochMap.get(params.lower, params.zeroForOne, tickMap, constants) <= cache.position.accumEpochLast
         ) {
             cache.earlyReturn = true;
             return cache;
@@ -58,7 +58,7 @@ library Claims {
         ) require (false, 'InvalidClaimTick()'); /// @dev - wrong claim tick
         if (params.claim < params.lower || params.claim > params.upper) require (false, 'InvalidClaimTick()');
 
-        uint32 claimTickEpoch = EpochMap.get(params.claim, tickMap, constants);
+        uint32 claimTickEpoch = EpochMap.get(params.claim, params.zeroForOne, tickMap, constants);
 
         // validate claim tick
         if (params.claim == (params.zeroForOne ? params.lower : params.upper)) {
@@ -67,8 +67,8 @@ library Claims {
         } else {
             // zero fill or partial fill
             uint32 claimTickNextAccumEpoch = params.zeroForOne
-                ? EpochMap.get(TickMap.previous(params.claim, tickMap, constants), tickMap, constants)
-                : EpochMap.get(TickMap.next(params.claim, tickMap, constants), tickMap, constants);
+                ? EpochMap.get(TickMap.previous(params.claim, tickMap, constants), params.zeroForOne, tickMap, constants)
+                : EpochMap.get(TickMap.next(params.claim, tickMap, constants), params.zeroForOne, tickMap, constants);
             ///@dev - next accumEpoch should not be greater
             if (claimTickNextAccumEpoch > cache.position.accumEpochLast) {
                 require (false, 'WrongTickClaimedAt()');

--- a/contracts/libraries/Epochs.sol
+++ b/contracts/libraries/Epochs.sol
@@ -194,7 +194,7 @@ library Epochs {
             (cache, pool0) = _rollover(state, cache, pool0, constants, true);
             if (cache.nextTickToAccum0 > cache.stopTick0 
                  && ticks[cache.nextTickToAccum0].amountInDeltaMaxMinus > 0) {
-                EpochMap.set(cache.nextTickToAccum0, state.accumEpoch, tickMap, constants);
+                EpochMap.set(cache.nextTickToAccum0, state.accumEpoch, true, tickMap, constants);
             }
             // accumulate to next tick
             CoverPoolStructs.AccumulateParams memory params = CoverPoolStructs.AccumulateParams({
@@ -250,7 +250,7 @@ library Epochs {
                 pool0.liquidity,
                 true
             );
-            EpochMap.set(cache.stopTick0, state.accumEpoch, tickMap, constants);
+            EpochMap.set(cache.stopTick0, state.accumEpoch, true, tickMap, constants);
             ticks[cache.stopTick0] = stopTick0;
         }
 
@@ -260,7 +260,7 @@ library Epochs {
             // accumulate deltas pool1
             if (cache.nextTickToAccum1 < cache.stopTick1 
                  && ticks[cache.nextTickToAccum1].amountInDeltaMaxMinus > 0) {
-                EpochMap.set(cache.nextTickToAccum1, state.accumEpoch, tickMap, constants);
+                EpochMap.set(cache.nextTickToAccum1, state.accumEpoch, false, tickMap, constants);
             }
             {
                 CoverPoolStructs.AccumulateParams memory params = CoverPoolStructs.AccumulateParams({
@@ -317,7 +317,7 @@ library Epochs {
                 false
             );
             ticks[cache.stopTick1] = stopTick1;
-            EpochMap.set(cache.stopTick1, state.accumEpoch, tickMap, constants);
+            EpochMap.set(cache.stopTick1, state.accumEpoch, false, tickMap, constants);
         }
         // update ending pool price for fully filled auction
         state.latestPrice = ConstantProduct.getPriceAtTick(cache.newLatestTick, constants);

--- a/contracts/libraries/Positions.sol
+++ b/contracts/libraries/Positions.sol
@@ -168,10 +168,10 @@ library Positions {
             if (
                 params.zeroForOne
                     ? state.latestTick < params.upper ||
-                        EpochMap.get(TickMap.previous(params.upper, tickMap, constants), tickMap, constants)
+                        EpochMap.get(TickMap.previous(params.upper, tickMap, constants), params.zeroForOne, tickMap, constants)
                             > cache.position.accumEpochLast
                     : state.latestTick > params.lower ||
-                        EpochMap.get(TickMap.next(params.lower, tickMap, constants), tickMap, constants)
+                        EpochMap.get(TickMap.next(params.lower, tickMap, constants), params.zeroForOne, tickMap, constants)
                             > cache.position.accumEpochLast
             ) {
                 require (false, string.concat('UpdatePositionFirstAt(', String.from(params.lower), ', ', String.from(params.upper), ')'));
@@ -267,10 +267,10 @@ library Positions {
             if (
                 params.zeroForOne
                     ? state.latestTick < params.upper ||
-                        EpochMap.get(TickMap.previous(params.upper, tickMap, constants), tickMap, constants)
+                        EpochMap.get(TickMap.previous(params.upper, tickMap, constants), params.zeroForOne, tickMap, constants)
                             > cache.position.accumEpochLast
                     : state.latestTick > params.lower ||
-                        EpochMap.get(TickMap.next(params.lower, tickMap, constants), tickMap, constants)
+                        EpochMap.get(TickMap.next(params.lower, tickMap, constants), params.zeroForOne, tickMap, constants)
                             > cache.position.accumEpochLast
             ) {
                 require (false, 'WrongTickClaimedAt()');


### PR DESCRIPTION
This PR adds separate epochs for `pool0` and `pool1` such that they never overwrite each other.