### PR TITLE
Simply `QuoteCall.sol`

### DIFF
--- a/contracts/CoverPool.sol
+++ b/contracts/CoverPool.sol
@@ -143,25 +143,13 @@ contract CoverPool is
             immutables()
         );
 
-        cache = SwapCall.perform(
+        return SwapCall.perform(
             params,
             cache,
             globalState,
             pool0,
             pool1
         );
-
-        if (params.zeroForOne) {
-            return (
-                -int256(cache.input) + int128(cache.syncFees.token0),
-                int256(cache.output + cache.syncFees.token1)
-            );
-        } else {
-            return (
-                int256(cache.output + cache.syncFees.token0),
-                -int256(cache.input) + int128(cache.syncFees.token1)
-            );
-        }
     }
 
     function quote(
@@ -189,20 +177,7 @@ contract CoverPool is
             cache.state,
             cache.constants
         );
-        cache = QuoteCall.perform(params, cache);
-        if (params.zeroForOne) {
-            return (
-                int256(cache.input) - int128(cache.syncFees.token0),
-                int256(cache.output + cache.syncFees.token1),
-                cache.price
-            );
-        } else {
-            return (
-                int256(cache.input) - int128(cache.syncFees.token1),
-                int256(cache.output + cache.syncFees.token0),
-                cache.price
-            );
-        }
+        return QuoteCall.perform(params, cache);
     }
 
     function snapshot(

--- a/contracts/libraries/Epochs.sol
+++ b/contracts/libraries/Epochs.sol
@@ -407,7 +407,6 @@ library Epochs {
         CoverPoolStructs.AccumulateCache memory,
         CoverPoolStructs.PoolState memory
     ) {
-        //TODO: add syncing fee
         if (pool.liquidity == 0) {
             return (cache, pool);
         }

--- a/contracts/libraries/Ticks.sol
+++ b/contracts/libraries/Ticks.sol
@@ -146,7 +146,7 @@ library Ticks {
         int24 upper,
         uint128 amount,
         bool isPool0
-    ) external {
+    ) internal {
         /// @dev - validation of ticks is in Positions.validate
         if (amount > uint128(type(int128).max)) require (false, 'LiquidityOverflow()');
         if ((uint128(type(int128).max) - state.liquidityGlobal) < amount)
@@ -161,15 +161,15 @@ library Ticks {
 
         // updates liquidity values
         if (isPool0) {
-                tickLower.liquidityDelta -= int128(amount);
+            tickLower.liquidityDelta -= int128(amount);
         } else {
-                tickLower.liquidityDelta += int128(amount);
+            tickLower.liquidityDelta += int128(amount);
         }
 
         TickMap.set(upper, tickMap, constants);
 
         if (isPool0) {
-                tickUpper.liquidityDelta += int128(amount);
+            tickUpper.liquidityDelta += int128(amount);
         } else {
             tickUpper.liquidityDelta -= int128(amount);
         }
@@ -187,7 +187,7 @@ library Ticks {
         bool isPool0,
         bool removeLower,
         bool removeUpper
-    ) external {
+    ) internal {
         {
             CoverPoolStructs.Tick memory tickLower = ticks[lower];
             if (removeLower) {

--- a/contracts/libraries/pool/QuoteCall.sol
+++ b/contracts/libraries/pool/QuoteCall.sol
@@ -5,38 +5,73 @@ import '../../interfaces/structs/CoverPoolStructs.sol';
 import '../../interfaces/ICoverPool.sol';
 import '../Ticks.sol';
 
-
 library QuoteCall {
 
     function perform(
         ICoverPool.QuoteParams memory params,
         CoverPoolStructs.SwapCache memory cache
     ) external view returns (
+        int256,
+        int256,
+        uint256
+    ) {
+        {
+            CoverPoolStructs.PoolState memory pool = params.zeroForOne ? cache.pool1 : cache.pool0;
+            cache = CoverPoolStructs.SwapCache({
+                state: cache.state,
+                syncFees: cache.syncFees,
+                constants: cache.constants,
+                pool0: cache.pool0,
+                pool1: cache.pool1,
+                price: pool.price,
+                liquidity: pool.liquidity,
+                amountLeft: params.amount,
+                auctionDepth: block.timestamp - cache.constants.genesisTime - cache.state.auctionStart,
+                auctionBoost: 0,
+                input: 0,
+                output: 0,
+                amountBoosted: 0,
+                amountInDelta: 0,
+                amount0Delta: 0,
+                amount1Delta: 0,
+                exactIn: true
+            });
+        }
+        // call quote
+        cache = Ticks.quote(
+            params.zeroForOne,
+            params.priceLimit,
+            cache.state,
+            cache,
+            cache.constants
+        );
+
+        // calculate deltas
+        cache = calculateDeltas(params, cache);
+        
+        return (
+            params.zeroForOne ? -cache.amount0Delta : -cache.amount1Delta,
+            params.zeroForOne ? cache.amount1Delta : cache.amount0Delta,
+            cache.price
+        );
+    }
+
+    function calculateDeltas(
+        ICoverPool.QuoteParams memory params,
+        CoverPoolStructs.SwapCache memory cache
+    ) internal pure returns (
         CoverPoolStructs.SwapCache memory
     ) {
-    {
-        CoverPoolStructs.PoolState memory pool = params.zeroForOne ? cache.pool1 : cache.pool0;
-        cache = CoverPoolStructs.SwapCache({
-            state: cache.state,
-            syncFees: cache.syncFees,
-            constants: cache.constants,
-            pool0: cache.pool0,
-            pool1: cache.pool1,
-            price: pool.price,
-            liquidity: pool.liquidity,
-            amountLeft: params.amount,
-            auctionDepth: block.timestamp - cache.constants.genesisTime - cache.state.auctionStart,
-            auctionBoost: 0,
-            input: 0,
-            output: 0,
-            amountBoosted: 0,
-            amountInDelta: 0,
-            amount0Delta: 0,
-            amount1Delta: 0,
-            exactIn: true
-        });
-    }
-        cache = Ticks.quote(params.zeroForOne, params.priceLimit, cache.state, cache, cache.constants);
+        // calculate amount deltas
+        cache.amount0Delta = params.zeroForOne ? -int256(cache.input) 
+                                               : int256(cache.output);
+        cache.amount1Delta = params.zeroForOne ? int256(cache.output) 
+                                               : -int256(cache.input);
+        
+        // factor in sync fees
+        cache.amount0Delta += int128(cache.syncFees.token0);
+        cache.amount1Delta += int128(cache.syncFees.token1);
+
         return cache;
     }
 }

--- a/test/contracts/coverpool.ts
+++ b/test/contracts/coverpool.ts
@@ -279,7 +279,6 @@ describe('CoverPool Tests', function () {
             revertMessage: '',
         })
 
-
         await validateBurn({
             signer: hre.props.alice,
             lower: '-40',

--- a/test/contracts/modules/curves/constantproduct.ts
+++ b/test/contracts/modules/curves/constantproduct.ts
@@ -14,8 +14,6 @@ describe('DyDxMath Library Tests', function () {
     let bob: SignerWithAddress
     let carol: SignerWithAddress
 
-    //TODO: mint position and burn as if there were 100
-
     before(async function () {
         await gBefore()
     })

--- a/test/utils/contracts/coverpool.ts
+++ b/test/utils/contracts/coverpool.ts
@@ -183,7 +183,6 @@ export async function validateSync(newLatestTick: number, autoSync: boolean = tr
     const oldLatestTick: number = globalState.latestTick
     const tickSpread: number = await hre.props.coverPool.tickSpread()
 
-    // //TODO: wait number of blocks equal to (twapMove * auctionLength)
     if (newLatestTick != oldLatestTick && hre.network.name == 'hardhat') {
         // mine until end of auction
         const auctionLength: number = await hre.props.coverPool.auctionLength()
@@ -339,7 +338,8 @@ export async function validateSwap(params: ValidateSwapParams) {
 
     expect(balanceInBefore.sub(balanceInAfter)).to.be.equal(balanceInDecrease)
     expect(balanceOutAfter.sub(balanceOutBefore)).to.be.equal(balanceOutIncrease)
-    //TODO: validate quote amount
+    /// @dev - quoted amount changes because swap happens on a new block with a new timestamp
+    // we would need to use the router to do a quote and then a swap in the same block
     // expect(balanceInBefore.sub(balanceInAfter)).to.be.equal(amountInQuoted)
     // expect(balanceOutAfter.sub(balanceOutBefore)).to.be.equal(amountOutQuoted)
 


### PR DESCRIPTION
This PR conforms code between `SwapCall.sol` and `QuoteCall.sol` such that the quoted amounts can be sufficiently trusted as being accurate.

When we execute the swap there is an increase in `block.timestamp` and thus the actual swapped amounts will differ from the quote.