### PR TITLE
Router testing

### DIFF
--- a/contracts/CoverPool.sol
+++ b/contracts/CoverPool.sol
@@ -1,8 +1,8 @@
 // SPDX-License-Identifier: BUSL-1.1
-pragma solidity ^0.8.13;
+pragma solidity 0.8.13;
 
-import './interfaces/ICoverPool.sol';
-import './interfaces/ICoverPoolManager.sol';
+import './interfaces/cover/ICoverPool.sol';
+import './interfaces/cover/ICoverPoolManager.sol';
 import './base/storage/CoverPoolStorage.sol';
 import './base/storage/CoverPoolImmutables.sol';
 import './interfaces/structs/PoolsharkStructs.sol';

--- a/contracts/CoverPoolFactory.sol
+++ b/contracts/CoverPoolFactory.sol
@@ -1,10 +1,10 @@
 // SPDX-License-Identifier: BUSL-1.1
-pragma solidity ^0.8.13;
+pragma solidity 0.8.13;
 
 import './CoverPool.sol';
 import './external/solady/LibClone.sol';
 import './interfaces/structs/CoverPoolStructs.sol';
-import './interfaces/ICoverPoolFactory.sol';
+import './interfaces/cover/ICoverPoolFactory.sol';
 import './base/events/CoverPoolFactoryEvents.sol';
 import './utils/CoverPoolErrors.sol';
 

--- a/contracts/base/events/CoverPoolEvents.sol
+++ b/contracts/base/events/CoverPoolEvents.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: GPL-3.0-or-later
-pragma solidity ^0.8.13;
+pragma solidity 0.8.13;
 
 abstract contract CoverPoolEvents {
         event Mint(

--- a/contracts/base/events/CoverPoolFactoryEvents.sol
+++ b/contracts/base/events/CoverPoolFactoryEvents.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: GPL-3.0-or-later
-pragma solidity ^0.8.13;
+pragma solidity 0.8.13;
 
 abstract contract CoverPoolFactoryEvents {
     event PoolCreated(

--- a/contracts/base/storage/CoverPoolFactoryStorage.sol
+++ b/contracts/base/storage/CoverPoolFactoryStorage.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: BUSL-1.1
-pragma solidity ^0.8.13;
+pragma solidity 0.8.13;
 
 abstract contract CoverPoolFactoryStorage {
     mapping(bytes32 => address) public coverPools;

--- a/contracts/base/storage/CoverPoolStorage.sol
+++ b/contracts/base/storage/CoverPoolStorage.sol
@@ -1,8 +1,8 @@
 // SPDX-License-Identifier: BUSL-1.1
-pragma solidity ^0.8.13;
+pragma solidity 0.8.13;
 
 import '../../interfaces/structs/CoverPoolStructs.sol';
-import '../../interfaces/ICoverPoolFactory.sol';
+import '../../interfaces/cover/ICoverPoolFactory.sol';
 import '../../utils/CoverPoolErrors.sol';
 
 abstract contract CoverPoolStorage is CoverPoolStructs, CoverPoolErrors {

--- a/contracts/interfaces/cover/ICoverPool.sol
+++ b/contracts/interfaces/cover/ICoverPool.sol
@@ -1,8 +1,8 @@
 // SPDX-License-Identifier: GPL-3.0-or-later
-pragma solidity ^0.8.13;
+pragma solidity 0.8.13;
 
-import './structs/CoverPoolStructs.sol';
-import './structs/PoolsharkStructs.sol';
+import '../structs/CoverPoolStructs.sol';
+import '../structs/PoolsharkStructs.sol';
 
 /**
  * @title ICoverPool

--- a/contracts/interfaces/cover/ICoverPoolFactory.sol
+++ b/contracts/interfaces/cover/ICoverPoolFactory.sol
@@ -1,6 +1,7 @@
 // SPDX-License-Identifier: BUSL-1.1
-pragma solidity ^0.8.13;
-import '../base/storage/CoverPoolFactoryStorage.sol';
+pragma solidity 0.8.13;
+
+import '../../base/storage/CoverPoolFactoryStorage.sol';
 
 abstract contract ICoverPoolFactory is CoverPoolFactoryStorage {
 

--- a/contracts/interfaces/cover/ICoverPoolManager.sol
+++ b/contracts/interfaces/cover/ICoverPoolManager.sol
@@ -1,7 +1,7 @@
 // SPDX-License-Identifier: GPL-3.0-or-later
 pragma solidity 0.8.13;
 
-import '../interfaces/structs/CoverPoolStructs.sol';
+import '../../interfaces/structs/CoverPoolStructs.sol';
 
 /// @notice CoverPoolManager interface
 interface ICoverPoolManager is CoverPoolStructs {

--- a/contracts/interfaces/external/uniswap/v3/IUniswapV3Pool.sol
+++ b/contracts/interfaces/external/uniswap/v3/IUniswapV3Pool.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: GPL-2.0-or-later
-pragma solidity ^0.8.13;
+pragma solidity 0.8.13;
 
 interface IUniswapV3Pool {
     /// @notice This is to be used at hedge pool initialization in case the cardinality is too low for the hedge pool.

--- a/contracts/interfaces/limit/ILimitPool.sol
+++ b/contracts/interfaces/limit/ILimitPool.sol
@@ -1,7 +1,7 @@
 // SPDX-License-Identifier: GPL-3.0-or-later
 pragma solidity 0.8.13;
 
-import '../interfaces/structs/PoolsharkStructs.sol';
+import '../structs/PoolsharkStructs.sol';
 
 interface ILimitPool is PoolsharkStructs {
     function immutables() external view returns (LimitImmutables memory);

--- a/contracts/interfaces/modules/sources/ITwapSource.sol
+++ b/contracts/interfaces/modules/sources/ITwapSource.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: GPL-3.0-or-later
-pragma solidity ^0.8.13;
+pragma solidity 0.8.13;
 
 import '../../structs/PoolsharkStructs.sol';
 

--- a/contracts/interfaces/structs/CoverPoolStructs.sol
+++ b/contracts/interfaces/structs/CoverPoolStructs.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: BUSL-1.1
-pragma solidity ^0.8.13;
+pragma solidity 0.8.13;
 
 import './PoolsharkStructs.sol';
 import '../modules/sources/ITwapSource.sol';

--- a/contracts/libraries/Claims.sol
+++ b/contracts/libraries/Claims.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: BUSL-1.1
-pragma solidity ^0.8.13;
+pragma solidity 0.8.13;
 
 import './Deltas.sol';
 import '../interfaces/structs/CoverPoolStructs.sol';

--- a/contracts/libraries/Deltas.sol
+++ b/contracts/libraries/Deltas.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: BUSL-1.1
-pragma solidity ^0.8.13;
+pragma solidity 0.8.13;
 
 import '../interfaces/structs/CoverPoolStructs.sol';
 import './math/ConstantProduct.sol';

--- a/contracts/libraries/EpochMap.sol
+++ b/contracts/libraries/EpochMap.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: BUSL-1.1
-pragma solidity ^0.8.13;
+pragma solidity 0.8.13;
 
 import './math/ConstantProduct.sol';
 import '../interfaces/structs/CoverPoolStructs.sol';

--- a/contracts/libraries/Epochs.sol
+++ b/contracts/libraries/Epochs.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: BUSL-1.1
-pragma solidity ^0.8.13;
+pragma solidity 0.8.13;
 
 import '../interfaces/modules/sources/ITwapSource.sol';
 import '../interfaces/structs/CoverPoolStructs.sol';

--- a/contracts/libraries/Positions.sol
+++ b/contracts/libraries/Positions.sol
@@ -1,10 +1,10 @@
 // SPDX-License-Identifier: BUSL-1.1
-pragma solidity ^0.8.13;
+pragma solidity 0.8.13;
 
 import './Ticks.sol';
 import './Deltas.sol';
 import '../interfaces/structs/CoverPoolStructs.sol';
-import '../interfaces/ICoverPool.sol';
+import '../interfaces/cover/ICoverPool.sol';
 import './math/OverflowMath.sol';
 import './Claims.sol';
 import './EpochMap.sol';

--- a/contracts/libraries/TickMap.sol
+++ b/contracts/libraries/TickMap.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: BUSL-1.1
-pragma solidity ^0.8.13;
+pragma solidity 0.8.13;
 
 import '../interfaces/structs/CoverPoolStructs.sol';
 import './math/ConstantProduct.sol';

--- a/contracts/libraries/Ticks.sol
+++ b/contracts/libraries/Ticks.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: BUSL-1.1
-pragma solidity ^0.8.13;
+pragma solidity 0.8.13;
 
 import '../interfaces/structs/CoverPoolStructs.sol';
 import '../utils/CoverPoolErrors.sol';

--- a/contracts/libraries/math/OverflowMath.sol
+++ b/contracts/libraries/math/OverflowMath.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-pragma solidity ^0.8.13;
+pragma solidity 0.8.13;
 
 /// @notice Math library that facilitates multiplication and division that can have overflow of an intermediate value without any loss of precision.
 library OverflowMath {

--- a/contracts/libraries/pool/BurnCall.sol
+++ b/contracts/libraries/pool/BurnCall.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-pragma solidity ^0.8.13;
+pragma solidity 0.8.13;
 
 import '../../interfaces/structs/CoverPoolStructs.sol';
 import '../Positions.sol';

--- a/contracts/libraries/pool/MintCall.sol
+++ b/contracts/libraries/pool/MintCall.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-pragma solidity ^0.8.13;
+pragma solidity 0.8.13;
 
 import '../../interfaces/structs/CoverPoolStructs.sol';
 import '../Positions.sol';

--- a/contracts/libraries/pool/QuoteCall.sol
+++ b/contracts/libraries/pool/QuoteCall.sol
@@ -1,8 +1,8 @@
 // SPDX-License-Identifier: MIT
-pragma solidity ^0.8.13;
+pragma solidity 0.8.13;
 
 import '../../interfaces/structs/CoverPoolStructs.sol';
-import '../../interfaces/ICoverPool.sol';
+import '../../interfaces/cover/ICoverPool.sol';
 import '../Ticks.sol';
 
 library QuoteCall {

--- a/contracts/libraries/pool/SwapCall.sol
+++ b/contracts/libraries/pool/SwapCall.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-pragma solidity ^0.8.13;
+pragma solidity 0.8.13;
 
 import '../../interfaces/structs/CoverPoolStructs.sol';
 import '../../interfaces/IERC20Minimal.sol';

--- a/contracts/libraries/sources/PoolsharkRangeSource.sol
+++ b/contracts/libraries/sources/PoolsharkRangeSource.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-pragma solidity ^0.8.13;
+pragma solidity 0.8.13;
 
 import '../../interfaces/external/poolshark/range/IRangePoolManager.sol';
 import '../../interfaces/external/poolshark/range/IRangePoolFactory.sol';

--- a/contracts/libraries/sources/UniswapV3Source.sol
+++ b/contracts/libraries/sources/UniswapV3Source.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-pragma solidity ^0.8.13;
+pragma solidity 0.8.13;
 
 import '../../interfaces/external/uniswap/v3/IUniswapV3Factory.sol';
 import '../../interfaces/external/uniswap/v3/IUniswapV3Pool.sol';

--- a/contracts/libraries/utils/Collect.sol
+++ b/contracts/libraries/utils/Collect.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-pragma solidity ^0.8.13;
+pragma solidity 0.8.13;
 
 import '../../interfaces/structs/CoverPoolStructs.sol';
 import '../Epochs.sol';

--- a/contracts/libraries/utils/String.sol
+++ b/contracts/libraries/utils/String.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-pragma solidity ^0.8.13;
+pragma solidity 0.8.13;
 
 library String {
     bytes16 private constant alphabet = "0123456789abcdef";

--- a/contracts/test/RangePoolFactoryMock.sol
+++ b/contracts/test/RangePoolFactoryMock.sol
@@ -1,5 +1,5 @@
 //SPDX-License-Identifier: Unlicense
-pragma solidity ^0.8.13;
+pragma solidity 0.8.13;
 
 import '../interfaces/external/poolshark/range/IRangePoolFactory.sol';
 import './RangePoolMock.sol';

--- a/contracts/test/RangePoolMock.sol
+++ b/contracts/test/RangePoolMock.sol
@@ -1,5 +1,5 @@
 //SPDX-License-Identifier: Unlicense
-pragma solidity ^0.8.13;
+pragma solidity 0.8.13;
 
 import '../interfaces/external/poolshark/range/IRangePool.sol';
 import './UniswapV3PoolMock.sol';

--- a/contracts/test/Token20.sol
+++ b/contracts/test/Token20.sol
@@ -1,5 +1,5 @@
 //SPDX-License-Identifier: Unlicense
-pragma solidity ^0.8.13;
+pragma solidity 0.8.13;
 
 import '@openzeppelin/contracts/token/ERC20/ERC20.sol';
 import '@openzeppelin/contracts/token/ERC20/extensions/ERC20Burnable.sol';

--- a/contracts/test/Token20Batcher.sol
+++ b/contracts/test/Token20Batcher.sol
@@ -1,5 +1,5 @@
 //SPDX-License-Identifier: Unlicense
-pragma solidity ^0.8.13;
+pragma solidity 0.8.13;
 
 import './Token20.sol';
 

--- a/contracts/test/UniswapV3FactoryMock.sol
+++ b/contracts/test/UniswapV3FactoryMock.sol
@@ -1,5 +1,5 @@
 //SPDX-License-Identifier: Unlicense
-pragma solidity ^0.8.13;
+pragma solidity 0.8.13;
 
 import '../interfaces/external/uniswap/v3/IUniswapV3Factory.sol';
 import './UniswapV3PoolMock.sol';

--- a/contracts/test/UniswapV3PoolMock.sol
+++ b/contracts/test/UniswapV3PoolMock.sol
@@ -1,5 +1,5 @@
 //SPDX-License-Identifier: Unlicense
-pragma solidity ^0.8.13;
+pragma solidity 0.8.13;
 
 import '../interfaces/external/uniswap/v3/IUniswapV3Pool.sol';
 import './UniswapV3PoolMock.sol';

--- a/contracts/utils/CoverPoolErrors.sol
+++ b/contracts/utils/CoverPoolErrors.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: BUSL-1.1
-pragma solidity ^0.8.13;
+pragma solidity 0.8.13;
 
 abstract contract CoverPoolErrors {
     error Locked();

--- a/contracts/utils/CoverPoolManager.sol
+++ b/contracts/utils/CoverPoolManager.sol
@@ -1,10 +1,10 @@
 // SPDX-License-Identifier: MIT
 
-pragma solidity ^0.8.0;
+pragma solidity 0.8.13;
 
-import '../interfaces/ICoverPool.sol';
-import '../interfaces/ICoverPoolFactory.sol';
-import '../interfaces/ICoverPoolManager.sol';
+import '../interfaces/cover/ICoverPool.sol';
+import '../interfaces/cover/ICoverPoolFactory.sol';
+import '../interfaces/cover/ICoverPoolManager.sol';
 import '../base/events/CoverPoolManagerEvents.sol';
 
 /**

--- a/contracts/utils/PoolsharkRouter.sol
+++ b/contracts/utils/PoolsharkRouter.sol
@@ -2,8 +2,8 @@
 pragma solidity 0.8.13;
 
 import '../interfaces/IPool.sol';
-import '../interfaces/ILimitPool.sol';
-import '../interfaces/ICoverPool.sol';
+import '../interfaces/limit/ILimitPool.sol';
+import '../interfaces/cover/ICoverPool.sol';
 import '../interfaces/callbacks/ILimitPoolSwapCallback.sol';
 import '../interfaces/callbacks/ICoverPoolSwapCallback.sol';
 import '../libraries/utils/SafeTransfers.sol';
@@ -140,6 +140,9 @@ contract PoolsharkRouter is
                     if (params[i].amount != params[0].amount) require(false, 'AmountParamMisMatch()');
                     /// @dev - priceLimit values are allowed to be different
                 }
+                unchecked {
+                    ++i;
+                }
             }
         }
         results = new QuoteResults[](pools.length);
@@ -150,7 +153,6 @@ contract PoolsharkRouter is
                 results[i].amountOut,
                 results[i].priceAfter
             ) = IPool(pools[i]).quote(params[i]);
-
             unchecked {
                 ++i;
             }
@@ -171,6 +173,9 @@ contract PoolsharkRouter is
                 if (params[i].zeroForOne != params[0].zeroForOne) require (false, 'ZeroForOneParamMismatch()');
                 if (params[i].exactIn != params[0].exactIn) require(false, 'ExactInParamMismatch()');
                 if (params[i].amount != params[0].amount) require(false, 'AmountParamMisMatch()');
+            }
+            unchecked {
+                ++i;
             }
         }
         for (uint i = 0; i < pools.length && params[0].amount > 0;) {
@@ -193,20 +198,6 @@ contract PoolsharkRouter is
                 }
                 params[i+1].amount = params[0].amount;
             }
-            unchecked {
-                ++i;
-            }
-        }
-    }
-
-    function multiCall(
-        address[] memory pools,
-        SwapParams[] memory params 
-    ) external {
-        if (pools.length != params.length) require(false, 'InputArrayLengthsMismatch()');
-        for (uint i = 0; i < pools.length;) {
-            params[i].callbackData = abi.encode(SwapCallbackData({sender: msg.sender}));
-            ICoverPool(pools[i]).swap(params[i]);
             unchecked {
                 ++i;
             }
@@ -247,7 +238,6 @@ contract PoolsharkRouter is
                         // indicate this result was already sorted
                         results[sortIndex].priceAfter = 0;
                     }
-
                     // continue finding nth element
                     unchecked {
                         ++index;

--- a/contracts/utils/PoolsharkRouter.sol
+++ b/contracts/utils/PoolsharkRouter.sol
@@ -163,6 +163,20 @@ contract PoolsharkRouter is
         }
     }
 
+    function multiCall(
+        address[] memory pools,
+        SwapParams[] memory params 
+    ) external {
+        if (pools.length != params.length) require(false, 'InputArrayLengthsMismatch()');
+        for (uint i = 0; i < pools.length;) {
+            params[i].callbackData = abi.encode(SwapCallbackData({sender: msg.sender}));
+            ICoverPool(pools[i]).swap(params[i]);
+            unchecked {
+                ++i;
+            }
+        }
+    }
+
     function multiSwapSplit(
         address[] memory pools,
         SwapParams[] memory params 

--- a/contracts/utils/RebaseLibrary.sol
+++ b/contracts/utils/RebaseLibrary.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: GPL-3.0-or-later
-pragma solidity ^0.8.13;
+pragma solidity 0.8.13;
 
 struct Rebase {
     uint128 elastic;

--- a/test/utils/contracts/coverpool.ts
+++ b/test/utils/contracts/coverpool.ts
@@ -206,7 +206,7 @@ export async function validateSync(newLatestTick: number, autoSync: boolean = tr
             txn = await hre.props.poolRouter
                     .connect(signer)
                     .multiCall(
-                    [hre.props.coverPool.address],  
+                    [hre.props.coverPool.address], 
                     [{
                         to: signer.address,
                         priceLimit: BigNumber.from('4297706460'),


### PR DESCRIPTION
This PR fixes `multiQuote` and `multiSwapSplit` and adds them into testing.

There seems to be less time delay with `multiSwapSplit` versus `multiCall`, so we will keep `multiCall` for now to pass tests.