### PR TITLE
Handle `Epochs.syncLatest()` at tick boundaries

### DIFF
--- a/contracts/libraries/Epochs.sol
+++ b/contracts/libraries/Epochs.sol
@@ -188,7 +188,7 @@ library Epochs {
                 ? cache.newLatestTick
                 : state.latestTick + constants.tickSpread
         });
-        while (cache.nextTickToCross0 > ConstantProduct.minTick(constants.tickSpread)) {
+        while (cache.nextTickToCross0 != cache.nextTickToAccum0) {
             // get values from current auction
             (cache, pool0) = _rollover(state, cache, pool0, constants, true);
             if (cache.nextTickToAccum0 > cache.stopTick0 
@@ -253,7 +253,7 @@ library Epochs {
             ticks[cache.stopTick0] = stopTick0;
         }
 
-        while (cache.nextTickToCross1 < ConstantProduct.maxTick(constants.tickSpread)) {
+        while (cache.nextTickToCross1 != cache.nextTickToAccum1) {
             // rollover deltas pool1
             (cache, pool1) = _rollover(state, cache, pool1, constants, false);
             // accumulate deltas pool1

--- a/contracts/libraries/Epochs.sol
+++ b/contracts/libraries/Epochs.sol
@@ -90,7 +90,7 @@ library Epochs {
                 : state.latestTick + constants.tickSpread
         });
 
-        while (cache.nextTickToCross0 > ConstantProduct.minTick(constants.tickSpread)) {
+        while (cache.nextTickToCross0 != cache.nextTickToAccum0) {
             // rollover and calculate sync fees
             (cache, pool0) = _rollover(state, cache, pool0, constants, true);
             // keep looping until accumulation reaches stopTick0 
@@ -107,7 +107,7 @@ library Epochs {
             } else break;
         }
 
-        while (cache.nextTickToCross1 < ConstantProduct.maxTick(constants.tickSpread)) {
+        while (cache.nextTickToCross1 != cache.nextTickToAccum1) {
             (cache, pool1) = _rollover(state, cache, pool1, constants, false);
             // keep looping until accumulation reaches stopTick1 
             if (cache.nextTickToAccum1 <= cache.stopTick1) {

--- a/contracts/libraries/Epochs.sol
+++ b/contracts/libraries/Epochs.sol
@@ -90,7 +90,7 @@ library Epochs {
                 : state.latestTick + constants.tickSpread
         });
 
-        while (true) {
+        while (cache.nextTickToCross0 > ConstantProduct.minTick(constants.tickSpread)) {
             // rollover and calculate sync fees
             (cache, pool0) = _rollover(state, cache, pool0, constants, true);
             // keep looping until accumulation reaches stopTick0 
@@ -107,7 +107,7 @@ library Epochs {
             } else break;
         }
 
-        while (true) {
+        while (cache.nextTickToCross1 < ConstantProduct.maxTick(constants.tickSpread)) {
             (cache, pool1) = _rollover(state, cache, pool1, constants, false);
             // keep looping until accumulation reaches stopTick1 
             if (cache.nextTickToAccum1 <= cache.stopTick1) {
@@ -188,8 +188,7 @@ library Epochs {
                 ? cache.newLatestTick
                 : state.latestTick + constants.tickSpread
         });
-
-        while (true) {
+        while (cache.nextTickToCross0 > ConstantProduct.minTick(constants.tickSpread)) {
             // get values from current auction
             (cache, pool0) = _rollover(state, cache, pool0, constants, true);
             if (cache.nextTickToAccum0 > cache.stopTick0 
@@ -254,7 +253,7 @@ library Epochs {
             ticks[cache.stopTick0] = stopTick0;
         }
 
-        while (true) {
+        while (cache.nextTickToCross1 < ConstantProduct.maxTick(constants.tickSpread)) {
             // rollover deltas pool1
             (cache, pool1) = _rollover(state, cache, pool1, constants, false);
             // accumulate deltas pool1
@@ -363,11 +362,14 @@ library Epochs {
         state.lastTime = uint32(block.timestamp) - constants.genesisTime;
         // check auctions elapsed
         uint32 timeElapsed = state.lastTime - state.auctionStart;
-        int32 auctionsElapsed = int32(timeElapsed / constants.auctionLength) - 1; /// @dev - subtract 1 for 3/4 twapLength check
+        int32 auctionsElapsed;
+        if (timeElapsed / constants.auctionLength <= uint32(type(int32).max))
+            auctionsElapsed = int32(timeElapsed / constants.auctionLength) - 1; /// @dev - subtract 1 for 3/4 twapLength check
+        else
+            auctionsElapsed = type(int32).max - 1;
         // if 3/4 of twapLength or auctionLength has passed allow for latestTick move
         if (timeElapsed > 3 * constants.twapLength / 4 ||
             timeElapsed > constants.auctionLength) auctionsElapsed += 1;
-
         if (auctionsElapsed < 1) {
             return (state.latestTick, true);
         }
@@ -393,7 +395,6 @@ library Epochs {
             if (state.latestTick - newLatestTick > maxLatestTickMove)
                 newLatestTick = state.latestTick - maxLatestTickMove;
         }
-
         return (newLatestTick, false);
     }
 

--- a/test/contracts/coverpool.ts
+++ b/test/contracts/coverpool.ts
@@ -19,6 +19,7 @@ import {
     CoverImmutables,
 } from '../utils/contracts/coverpool'
 import { gBefore } from '../utils/hooks.test'
+const { mine } = require("@nomicfoundation/hardhat-network-helpers");
 
 alice: SignerWithAddress
 describe('CoverPool Tests', function () {
@@ -179,6 +180,24 @@ describe('CoverPool Tests', function () {
             upperTickCleared: false,
             revertMessage: 'WaitUntilEnoughObservations()',
         })
+    })
+
+    it('pool0 - Should not encounter infinite loop at min bounds', async function () {
+        await validateSync(-1_000_000, true)
+        await mine(463588)
+        await validateSync(15, true)
+        await getLatestTick(true)
+        await validateSync(0, true)
+        await getLatestTick(true)
+    })
+
+    it('pool1 - Should not encounter infinite loop at max bounds', async function () {
+        await validateSync(1_000_000, true)
+        await mine(463588)
+        await validateSync(15, true)
+        await getLatestTick(true)
+        await validateSync(0, true)
+        await getLatestTick(true)
     })
 
     it('pool0 - Should mint/burn new LP position 71', async function () {

--- a/test/utils/contracts/coverpool.ts
+++ b/test/utils/contracts/coverpool.ts
@@ -182,13 +182,16 @@ export async function validateSync(newLatestTick: number, autoSync: boolean = tr
     const globalState = (await hre.props.coverPool.globalState())
     const oldLatestTick: number = globalState.latestTick
     const tickSpread: number = await hre.props.coverPool.tickSpread()
+    console.log('tick spread', tickSpread)
 
     if (newLatestTick != oldLatestTick && hre.network.name == 'hardhat') {
         // mine until end of auction
-        const auctionLength: number = await hre.props.coverPool.auctionLength()
-                                        * Math.abs(newLatestTick - oldLatestTick) / tickSpread;
+        const auctionLength: number = Math.trunc(await hre.props.coverPool.auctionLength()
+                                        * Math.abs(newLatestTick - oldLatestTick) / tickSpread);
+        console.log('auction length', auctionLength)
         await mine(auctionLength)
     }
+    console.log('set tick cumulatives')
     let txn = await hre.props.uniswapV3PoolMock.connect(signer).setTickCumulatives(
         newLatestTick * 10,
         newLatestTick * 8,
@@ -203,6 +206,7 @@ export async function validateSync(newLatestTick: number, autoSync: boolean = tr
 
     if (autoSync) {
         if (!revertMessage || revertMessage == '') {
+            console.log('swap')
             txn = await hre.props.poolRouter
                     .connect(signer)
                     .multiCall(
@@ -235,7 +239,7 @@ export async function validateSync(newLatestTick: number, autoSync: boolean = tr
         }
         await txn.wait()
     }
-    // console.log("-- END ACCUMULATE LAST BLOCK --");
+    console.log("-- END ACCUMULATE LAST BLOCK --");
     /// check tick status after
 }
 

--- a/test/utils/contracts/coverpool.ts
+++ b/test/utils/contracts/coverpool.ts
@@ -182,16 +182,13 @@ export async function validateSync(newLatestTick: number, autoSync: boolean = tr
     const globalState = (await hre.props.coverPool.globalState())
     const oldLatestTick: number = globalState.latestTick
     const tickSpread: number = await hre.props.coverPool.tickSpread()
-    console.log('tick spread', tickSpread)
 
     if (newLatestTick != oldLatestTick && hre.network.name == 'hardhat') {
         // mine until end of auction
         const auctionLength: number = Math.trunc(await hre.props.coverPool.auctionLength()
                                         * Math.abs(newLatestTick - oldLatestTick) / tickSpread);
-        console.log('auction length', auctionLength)
         await mine(auctionLength)
     }
-    console.log('set tick cumulatives')
     let txn = await hre.props.uniswapV3PoolMock.connect(signer).setTickCumulatives(
         newLatestTick * 10,
         newLatestTick * 8,
@@ -206,7 +203,6 @@ export async function validateSync(newLatestTick: number, autoSync: boolean = tr
 
     if (autoSync) {
         if (!revertMessage || revertMessage == '') {
-            console.log('swap')
             txn = await hre.props.poolRouter
                     .connect(signer)
                     .multiCall(
@@ -239,7 +235,6 @@ export async function validateSync(newLatestTick: number, autoSync: boolean = tr
         }
         await txn.wait()
     }
-    console.log("-- END ACCUMULATE LAST BLOCK --");
     /// check tick status after
 }
 


### PR DESCRIPTION
This PR handles two edge cases:

1) the uint16 value `auctionsElapsed` could be greater than the max int16 value and thus become negative
* this would skip the whole syncing process which is not intended behavior
* to solve for this we check if `auctionsElapsed` is greater than `uitn16(type(int16).max)`

2) check for `accumTick == crossTick` in `Epochs.syncLatest()`. This will always be true at the tick bounds.