### PR TITLE
Revert on Position Liquidity Zero

### DIFF
--- a/contracts/libraries/Positions.sol
+++ b/contracts/libraries/Positions.sol
@@ -145,7 +145,8 @@ library Positions {
         CoverPoolStructs.GlobalState memory,
         CoverPoolStructs.CoverPosition memory
     ) {
-        if (params.amount == 0) return (state, position);
+        if (params.amount == 0)
+            require(false, 'NoLiquidityBeingAdded()');
         // initialize cache
         CoverPoolStructs.CoverPositionCache memory cache = CoverPoolStructs.CoverPositionCache({
             position: position,

--- a/test/contracts/coverpool.ts
+++ b/test/contracts/coverpool.ts
@@ -182,22 +182,40 @@ describe('CoverPool Tests', function () {
         })
     })
 
+    it('pool0 - Should not mint position when amountInDeltaMax is zero', async function () {
+        await validateMint({
+            signer: hre.props.alice,
+            recipient: hre.props.alice.address,
+            lower: '-887260',
+            upper: '3000',
+            amount: BigNumber.from('1'),
+            zeroForOne: true,
+            balanceInDecrease: BigNumber.from('1'),
+            liquidityIncrease: BN_ZERO,
+            upperTickCleared: false,
+            lowerTickCleared: false,
+            revertMessage: 'NoLiquidityBeingAdded()'
+        })
+    })
+
     it('pool0 - Should not encounter infinite loop at min bounds', async function () {
         await validateSync(-1_000_000, true)
+
         await mine(463588)
+
         await validateSync(15, true)
-        await getLatestTick(true)
+
         await validateSync(0, true)
-        await getLatestTick(true)
     })
 
     it('pool1 - Should not encounter infinite loop at max bounds', async function () {
         await validateSync(1_000_000, true)
+
         await mine(463588)
+
         await validateSync(15, true)
-        await getLatestTick(true)
+
         await validateSync(0, true)
-        await getLatestTick(true)
     })
 
     it('pool0 - Should mint/burn new LP position 71', async function () {


### PR DESCRIPTION
This PR handles the minted liquidity being zero after calling `Positions.resize()`.

The position liquidity thereafter might be zero and not revert.

It was creating a position with an epoch of `0`, which could effectively claim at any tick in its range.

This might lead to small inbalances in the pool and possibly result in an ERC-20 balance underflow.